### PR TITLE
Introduce protobuf libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,7 @@ dependencies = [
  "flate2",
  "futures",
  "home",
+ "human-panic",
  "keyring",
  "reqwest",
  "serde",
@@ -868,6 +869,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
+name = "human-panic"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a841f87949b0dd751864e769a870be79dc34abcee1cf31d737a61d498b22b6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "backtrace",
+ "os_info",
+ "serde",
+ "serde_derive",
+ "toml",
+ "uuid",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,6 +1308,17 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_info"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e"
+dependencies = [
+ "log",
+ "serde",
+ "winapi",
 ]
 
 [[package]]
@@ -2051,6 +2079,15 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uuid"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d023da39d1fde5a8a3fe1f3e01ca9632ada0a63e9797de55a879d6e2236277be"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "buffrs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,7 @@ dependencies = [
  "keyring",
  "reqwest",
  "serde",
+ "serde_typename",
  "tar",
  "tokio",
  "toml",
@@ -1648,6 +1649,15 @@ name = "serde_spanned"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_typename"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2531ff92ba8ea226702685bdd332d30dd56e7d2717c322ec035fc7bb277abfbd"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ eyre = "0.6"
 flate2 = "1"
 futures = "0.3"
 home = "0.5.5"
+human-panic = "1"
 keyring = "2"
 reqwest = "0.11"
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buffrs"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "An opinionated protobuf package manager"
 authors = ["Mara Schulke <mara.schulke@helsing.ai>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,6 @@ toml = "0.7"
 toml_edit = "0.19"
 tracing = "0.1"
 tracing-subscriber = "0.3"
+serde_typename = "0.1"
 url = { version = "2.4", features = ["serde"] }
 walkdir = "2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,8 @@ enum Command {
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
+    human_panic::setup_panic!();
+
     color_eyre::install()?;
 
     tracing_subscriber::fmt()

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,7 @@ mod cmd {
     use buffrs::{
         config::Config,
         manifest::{Dependency, Manifest, PackageManifest},
-        package::{Package, PackageId, PackageStore, PackageType},
+        package::{PackageId, PackageStore, PackageType},
         registry::{Artifactory, ArtifactoryConfig, Registry},
     };
     use eyre::{ensure, Context, ContextCompat};
@@ -237,18 +237,10 @@ mod cmd {
 
         let manifest = Manifest::read().await?;
 
-        let mut packages = Vec::with_capacity(manifest.dependencies.len());
-
-        for dep in manifest.dependencies {
-            packages.push(artifactory.download(dep));
-        }
-
-        let packages: Vec<Package> = try_join_all(packages).await?;
-
         let mut install = Vec::new();
 
-        for package in packages {
-            install.push(PackageStore::install(package));
+        for dependency in manifest.dependencies {
+            install.push(PackageStore::install(dependency, artifactory.clone()));
         }
 
         try_join_all(install).await?;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt};
 use tokio::fs;
 
-use crate::package::PackageId;
+use crate::package::{PackageId, PackageType};
 
 pub const MANIFEST_FILE: &str = "Proto.toml";
 
@@ -15,7 +15,7 @@ pub const MANIFEST_FILE: &str = "Proto.toml";
 /// empty fields.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RawManifest {
-    pub api: Option<ApiManifest>,
+    pub package: Option<PackageManifest>,
     pub dependencies: Option<DependencyMap>,
 }
 
@@ -30,7 +30,7 @@ impl From<Manifest> for RawManifest {
         let dependencies = (!dependencies.is_empty()).then_some(dependencies);
 
         Self {
-            api: manifest.api,
+            package: manifest.package,
             dependencies,
         }
     }
@@ -43,7 +43,7 @@ pub type DependencyMap = HashMap<PackageId, DependencyManifest>;
 /// version of the `RawManifest` for easier use.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Manifest {
-    pub api: Option<ApiManifest>,
+    pub package: Option<PackageManifest>,
     pub dependencies: Vec<Dependency>,
 }
 
@@ -86,18 +86,20 @@ impl From<RawManifest> for Manifest {
             .collect();
 
         Self {
-            api: raw.api,
+            package: raw.package,
             dependencies,
         }
     }
 }
 
 /// Manifest format for api packages
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ApiManifest {
-    /// Name of the api package
+#[derive(Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PackageManifest {
+    /// Type of the package
+    pub r#type: PackageType,
+    /// Name of the package
     pub name: PackageId,
-    /// Version of the api package
+    /// Version of the package
     pub version: String,
     /// Description of the api package
     pub description: Option<String>,

--- a/src/package.rs
+++ b/src/package.rs
@@ -78,9 +78,7 @@ impl PackageStore {
 
         let pkg_dir = path.join(package.manifest.name.as_package_dir());
 
-        fs::remove_dir_all(&pkg_dir)
-            .await
-            .wrap_err(format!("Failed to uninstall {}", package.manifest.name))?;
+        fs::remove_dir_all(&pkg_dir).await.ok();
 
         fs::create_dir_all(&pkg_dir)
             .await

--- a/src/package.rs
+++ b/src/package.rs
@@ -105,10 +105,9 @@ impl PackageStore {
 
         Self::unpack(&package, dep_dir).await?;
 
-        tracing::info!(
+        let mut tree = format!(
             ":: installed {}@{}",
-            package.manifest.name,
-            package.manifest.version
+            package.manifest.name, package.manifest.version
         );
 
         let Manifest { dependencies, .. } = Self::resolve(&package.manifest.name).await?;
@@ -128,12 +127,13 @@ impl PackageStore {
                 '┣'
             };
 
-            tracing::info!(
-                "   {tree_char} installed {}@{}",
-                dependency.manifest.name,
-                dependency.manifest.version
-            );
+            tree.push_str(&format!(
+                "\n   {tree_char} installed {}@{}",
+                dependency.manifest.name, dependency.manifest.version
+            ));
         }
+
+        tracing::info!("{tree}");
 
         Ok(())
     }

--- a/src/package.rs
+++ b/src/package.rs
@@ -271,9 +271,12 @@ impl Package {
     pub fn new(manifest: PackageManifest, tgz: Bytes) -> Self {
         Self { manifest, tgz }
     }
+}
 
-    /// Decodes the tar and returns the encoded manifest
-    pub fn decode(tgz: Bytes) -> eyre::Result<Self> {
+impl TryFrom<Bytes> for Package {
+    type Error = eyre::Error;
+
+    fn try_from(tgz: Bytes) -> eyre::Result<Self> {
         let mut tar = Vec::new();
 
         let mut gz = flate2::read::GzDecoder::new(tgz.clone().reader());

--- a/src/registry/artifactory.rs
+++ b/src/registry/artifactory.rs
@@ -40,18 +40,18 @@ impl Registry for Artifactory {
 
         let tgz = response.bytes().await.wrap_err("Failed to download tar")?;
 
-        Ok(Package::new(
-            dependency.package,
-            dependency.manifest.version,
-            tgz,
-        ))
+        Package::decode(tgz)
     }
 
     /// Publishes a package to artifactory
     async fn publish(&self, package: Package, repository: String) -> eyre::Result<()> {
         let artifact_uri: Url = format!(
             "{}/{}/{}/{}-{}.tgz",
-            self.0.url, repository, package.name, package.name, package.version
+            self.0.url,
+            repository,
+            package.manifest.name,
+            package.manifest.name,
+            package.manifest.version,
         )
         .parse()
         .wrap_err("Failed to construct artifact uri")?;
@@ -66,14 +66,14 @@ impl Registry for Artifactory {
         ensure!(
             response.status().is_success(),
             "Failed to publish {}",
-            package.name
+            package.manifest.name
         );
 
         tracing::info!(
-            "+ pubished {}/{}@{}",
+            "+ published {}/{}@{}",
             repository,
-            package.name,
-            package.version
+            package.manifest.name,
+            package.manifest.version
         );
 
         Ok(())

--- a/src/registry/artifactory.rs
+++ b/src/registry/artifactory.rs
@@ -43,7 +43,7 @@ impl Registry for Artifactory {
 
         let tgz = response.bytes().await.wrap_err("Failed to download tar")?;
 
-        Package::decode(tgz)
+        Package::try_from(tgz)
     }
 
     /// Publishes a package to artifactory

--- a/src/registry/artifactory.rs
+++ b/src/registry/artifactory.rs
@@ -1,5 +1,7 @@
 // (c) Copyright 2023 Helsing GmbH. All rights reserved.
 
+use std::sync::Arc;
+
 use eyre::{ensure, Context};
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -8,7 +10,8 @@ use super::Registry;
 use crate::{manifest::Dependency, package::Package};
 
 /// The registry implementation for artifactory
-pub struct Artifactory(ArtifactoryConfig);
+#[derive(Debug, Clone)]
+pub struct Artifactory(Arc<ArtifactoryConfig>);
 
 #[async_trait::async_trait]
 impl Registry for Artifactory {
@@ -70,7 +73,7 @@ impl Registry for Artifactory {
         );
 
         tracing::info!(
-            "+ published {}/{}@{}",
+            ":: published {}/{}@{}",
             repository,
             package.manifest.name,
             package.manifest.version
@@ -82,7 +85,7 @@ impl Registry for Artifactory {
 
 impl From<ArtifactoryConfig> for Artifactory {
     fn from(cfg: ArtifactoryConfig) -> Self {
-        Self(cfg)
+        Self(cfg.into())
     }
 }
 


### PR DESCRIPTION
Introduces:

- The `lib` package types (and thus adjusts the manifest format)
- Scoped and nested dependency resolution (installing libraries needed for api packages you consume)