### PR TITLE
Error on code generation if no dependencies are given

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -89,6 +89,11 @@ pub async fn generate(language: Language) -> eyre::Result<()> {
 
     tracing::info!(":: initializing code generator for {language}");
 
+    eyre::ensure!(
+        !manifest.dependencies.is_empty(),
+        "At least one dependency is needed to generate code bindings."
+    );
+
     // Only tonic is supported right now
     let generator = Generator::Tonic;
 


### PR DESCRIPTION
This makes it more obvious to the user what's going on and why there's no output.