### PR TITLE
Refactor vendor dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "buffrs"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buffrs"
-version = "0.3.5"
+version = "0.4.0"
 edition = "2021"
 description = "An opinionated protobuf package manager"
 authors = ["Mara Schulke <mara.schulke@helsing.ai>"]

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -45,7 +45,7 @@ impl Generator {
     pub const TONIC_INCLUDE_FILE: &str = "mod.rs";
 
     /// Run the generator for a dependency and output files into `out`
-    pub async fn run(&self, output: &Path) -> eyre::Result<()> {
+    pub async fn run(&self, output: impl AsRef<Path>) -> eyre::Result<()> {
         let protoc = protoc_bin_path().wrap_err("Unable to locate vendored protoc")?;
 
         std::env::set_var("PROTOC", protoc.clone());

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -44,7 +44,7 @@ pub enum Generator {
 impl Generator {
     pub const TONIC_INCLUDE_FILE: &str = "mod.rs";
 
-    /// Run the generator for a dependency and output files into `out`
+    /// Run the generator for a dependency and output files at the provided path
     pub async fn run(&self, output: impl AsRef<Path>) -> eyre::Result<()> {
         let protoc = protoc_bin_path().wrap_err("Unable to locate vendored protoc")?;
 

--- a/src/package.rs
+++ b/src/package.rs
@@ -106,7 +106,7 @@ impl PackageStore {
 
                 eyre::ensure!(
                     existing.version == dependency.manifest.version,
-                    "Another dependency in your project requires {}@{} which colides with {}@{} required by {}",
+                    "A dependency of your project requires {}@{} which collides with {}@{} required by {}",
                     existing.name,
                     existing.version,
                     dependency.package,

--- a/src/package.rs
+++ b/src/package.rs
@@ -51,7 +51,7 @@ impl PackageStore {
     }
 
     /// Unpacks a package into a local directory
-    pub async fn unpack(package: &Package, path: &Path) -> eyre::Result<()> {
+    pub async fn unpack(package: &Package) -> eyre::Result<()> {
         let mut tar = Vec::new();
 
         let mut gz = flate2::read::GzDecoder::new(package.tgz.clone().reader());
@@ -61,7 +61,7 @@ impl PackageStore {
 
         let mut tar = tar::Archive::new(Bytes::from(tar).reader());
 
-        let pkg_dir = path.join(package.manifest.name.as_str());
+        let pkg_dir = Path::new(Self::PROTO_VENDOR_PATH).join(package.manifest.name.as_str());
 
         fs::remove_dir_all(&pkg_dir).await.ok();
 
@@ -86,9 +86,7 @@ impl PackageStore {
     pub async fn install<R: Registry>(dependency: Dependency, registry: R) -> eyre::Result<()> {
         let package = registry.download(dependency).await?;
 
-        let vendor_dir = Path::new(Self::PROTO_VENDOR_PATH);
-
-        Self::unpack(&package, vendor_dir).await?;
+        Self::unpack(&package).await?;
 
         let mut tree = format!(
             ":: installed {}@{}",
@@ -97,14 +95,29 @@ impl PackageStore {
 
         let Manifest { dependencies, .. } = Self::resolve(&package.manifest.name).await?;
 
-        let package_dir = &vendor_dir.join(package.manifest.name.as_str());
-
         let dependency_count = dependencies.len();
 
         for (index, dependency) in dependencies.into_iter().enumerate() {
+            if let Ok(manifest) = Self::resolve(&dependency.package).await {
+                let existing = manifest.package.wrap_err(eyre::eyre!(
+                    "Found installed manifest for {} but it is malformed",
+                    dependency.package,
+                ))?;
+
+                eyre::ensure!(
+                    existing.version == dependency.manifest.version,
+                    "Another dependency in your project requires {}@{} which colides with {}@{} required by {}",
+                    existing.name,
+                    existing.version,
+                    dependency.package,
+                    dependency.manifest.version,
+                    package.manifest.name,
+                );
+            }
+
             let dependency = registry.download(dependency).await?;
 
-            Self::unpack(&dependency, package_dir).await?;
+            Self::unpack(&dependency).await?;
 
             let tree_char = if index + 1 == dependency_count {
                 '┗'


### PR DESCRIPTION
## Changes

This pr refactors the package store from:

```
proto
  /vendor/
    <a>/
      Proto.toml
      vendor/<c>/..
    <b>/
      Proto.toml
      vendor/<c>/..
```

To 

```
proto
  /vendor/
    <a>/
      Proto.toml
      ..
    <b>/
      Proto.toml
      ..
    <c>/
      Proto.toml
      ..
```

And simplifies code generation implementation.

## Upsides

This drastically simplifies the package store layout, and more importantly, enables people to compile it using *any* protobuf code gen tool, such as protoc without any change.

Furthermore it removes the type duplication problem that occured when nesting dependencies:

Before the change, you had two version of the `c` library types:

```rust
mod a {
  mod c { /* ... */ }
}

mod b {
  mod c { /* ... */ }
}
```

Which is now resolved, since tonic generates this structure:

```rust
mod a { /* ... */ }
mod b { /* ... */ }
mod c { /* ... */ }
```

## Downsides

This change has the implication that *all* dependencies may only use one single version of `c` which is not ideal. We can and will solve this by introducing proper version resolution mechanism soon.