### PR TITLE
Start implementing semver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,7 @@ dependencies = [
  "human-panic",
  "protoc-bin-vendored",
  "reqwest",
+ "semver",
  "serde",
  "serde_typename",
  "tar",
@@ -1366,6 +1367,15 @@ checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ protoc-bin-vendored = "3.0.0"
 reqwest = "0.11"
 serde = { version = "1", features = ["derive"] }
 serde_typename = "0.1"
+semver = { version = "1", features = ["serde"] }
 tar = "0.4"
 tokio = { version = "1", features = ["full", "tracing"] }
 toml = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ pub fn build(language: Language) -> eyre::Result<()> {
                     )
                 })?;
 
-                if pkg.version == dependency.manifest.version {
+                if dependency.manifest.version.matches(&pkg.version) {
                     continue;
                 }
             }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,6 +1,7 @@
 // (c) Copyright 2023 Helsing GmbH. All rights reserved.
 
 use eyre::Context;
+use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt};
 use tokio::fs;
@@ -100,13 +101,13 @@ pub struct PackageManifest {
     /// Name of the package
     pub name: PackageId,
     /// Version of the package
-    pub version: String,
+    pub version: Version,
     /// Description of the api package
     pub description: Option<String>,
 }
 
 /// Represents a single project dependency
-#[derive(Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Dependency {
     /// Package name of this dependency
     pub package: PackageId,
@@ -116,7 +117,7 @@ pub struct Dependency {
 
 impl Dependency {
     /// Creates a new dependency
-    pub fn new(repository: String, package: PackageId, version: String) -> Self {
+    pub fn new(repository: String, package: PackageId, version: VersionReq) -> Self {
         Self {
             package,
             manifest: DependencyManifest {
@@ -138,10 +139,10 @@ impl fmt::Display for Dependency {
 }
 
 /// Manifest format for dependencies
-#[derive(Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DependencyManifest {
     /// Version requirement in the helsing format, currently only supports pinning
-    pub version: String,
+    pub version: VersionReq,
     /// Artifactory repository to pull dependency from
     pub repository: String,
 }

--- a/src/package.rs
+++ b/src/package.rs
@@ -105,7 +105,7 @@ impl PackageStore {
                 ))?;
 
                 eyre::ensure!(
-                    existing.version == dependency.manifest.version,
+                    dependency.manifest.version.matches(&existing.version),
                     "A dependency of your project requires {}@{} which collides with {}@{} required by {}",
                     existing.name,
                     existing.version,

--- a/src/registry/artifactory.rs
+++ b/src/registry/artifactory.rs
@@ -40,6 +40,8 @@ impl Artifactory {
 impl Registry for Artifactory {
     /// Downloads a package from artifactory
     async fn download(&self, dependency: Dependency) -> eyre::Result<Package> {
+        todo!("IMPLEMENT VERSION RESOLUTION");
+
         let artifact_uri: Url = {
             let mut url = self.0.url.clone();
 

--- a/src/registry/artifactory.rs
+++ b/src/registry/artifactory.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use eyre::{ensure, Context};
+use eyre::{ensure, Context, ContextCompat};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -40,7 +40,35 @@ impl Artifactory {
 impl Registry for Artifactory {
     /// Downloads a package from artifactory
     async fn download(&self, dependency: Dependency) -> eyre::Result<Package> {
-        todo!("IMPLEMENT VERSION RESOLUTION");
+        ensure!(
+            dependency.manifest.version.comparators.len() == 1,
+            "{} uses unsupported semver comparators",
+            dependency.package
+        );
+
+        let version = dependency
+            .manifest
+            .version
+            .comparators
+            .first()
+            .wrap_err("internal error")?;
+
+        ensure!(
+            version.op == semver::Op::Exact && version.minor.is_some() && version.patch.is_some(),
+            "artifactory only support pinned dependencies"
+        );
+
+        let version = format!(
+            "{}.{}.{}{}",
+            version.major,
+            version.minor.wrap_err("internal error")?,
+            version.patch.wrap_err("internal error")?,
+            if version.pre.is_empty() {
+                "".to_owned()
+            } else {
+                format!("-{}", version.pre)
+            }
+        );
 
         let artifact_uri: Url = {
             let mut url = self.0.url.clone();
@@ -51,7 +79,7 @@ impl Registry for Artifactory {
                 dependency.manifest.repository,
                 dependency.package,
                 dependency.package,
-                dependency.manifest.version
+                version
             ));
 
             url


### PR DESCRIPTION
# Changes

Use the `semver` crate's types `Version` and `VersionReq` instead of strings

# Implications

Existing version requirements in manifests will result in errors as the default operator is `Caret` and only `Exact` is supported as of right now.

Example:

```
[dependencies]
pkg = { version = "1.0.0", repository = "foo" }
```

Will have to be changed to:
```
[dependencies]
pkg = { version = "=1.0.0", repository = "foo" }
```

---

The proper evalutation / resolution of requirements will be implemented by the registry (see #12)
