### PR TITLE
Decouple registry configuration from credentials / enable multiple registry support

### DIFF
--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -2,10 +2,15 @@
 
 use eyre::{Context, ContextCompat};
 use serde::{Deserialize, Serialize};
-use std::{env, path::PathBuf};
+use std::{
+    collections::HashMap,
+    env,
+    ops::{Deref, DerefMut},
+    path::PathBuf,
+};
 use tokio::fs;
 
-use crate::registry::ArtifactoryConfig;
+use crate::manifest::{RegistryToken, RegistryUri};
 
 /// Global configuration directory for `buffrs`
 pub const BUFFRS_HOME: &str = ".buffrs";
@@ -13,10 +18,23 @@ pub const BUFFRS_HOME: &str = ".buffrs";
 pub const CREDENTIALS_FILE: &str = "credentials.toml";
 
 /// Credential store for storing authentication data
-#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Default, Clone)]
 pub struct Credentials {
-    /// Artifactory credentials
-    pub artifactory: Option<ArtifactoryConfig>,
+    credentials: HashMap<RegistryUri, RegistryToken>,
+}
+
+impl Deref for Credentials {
+    type Target = HashMap<RegistryUri, RegistryToken>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.credentials
+    }
+}
+
+impl DerefMut for Credentials {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.credentials
+    }
 }
 
 impl Credentials {
@@ -41,7 +59,10 @@ impl Credentials {
             .await
             .wrap_err("Failed to read credentials")?;
 
-        toml::from_str(&toml).wrap_err("Failed to parse credentials")
+        let raw: RawCredentialCollection =
+            toml::from_str(&toml).wrap_err("Failed to parse credentials")?;
+
+        Ok(raw.into())
     }
 
     /// Writes the credentials to the file system
@@ -54,7 +75,9 @@ impl Credentials {
         .await
         .ok();
 
-        fs::write(Self::location()?, toml::to_string(&self)?.into_bytes())
+        let data: RawCredentialCollection = self.clone().into();
+
+        fs::write(Self::location()?, toml::to_string(&data)?.into_bytes())
             .await
             .wrap_err("Failed to write credentials")
     }
@@ -70,5 +93,41 @@ impl Credentials {
         };
 
         Ok(credentials)
+    }
+}
+
+/// Credential store for storing authentication data. Serialization type.
+#[derive(Serialize, Deserialize)]
+pub struct RawCredentialCollection {
+    credentials: Vec<RawRegistryCredentials>,
+}
+
+/// Credentials for a single registry. Serialization type.
+#[derive(Serialize, Deserialize)]
+struct RawRegistryCredentials {
+    uri: RegistryUri,
+    token: RegistryToken,
+}
+
+impl From<RawCredentialCollection> for Credentials {
+    fn from(value: RawCredentialCollection) -> Self {
+        let credentials = value
+            .credentials
+            .into_iter()
+            .map(|it| (it.uri, it.token))
+            .collect();
+        Self { credentials }
+    }
+}
+
+impl From<Credentials> for RawCredentialCollection {
+    fn from(value: Credentials) -> Self {
+        let credentials = value
+            .credentials
+            .into_iter()
+            .map(|(uri, token)| RawRegistryCredentials { uri, token })
+            .collect();
+
+        Self { credentials }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub fn build(language: Language) -> eyre::Result<()> {
     async fn install() -> eyre::Result<()> {
         let credentials = Credentials::read().await?;
 
-        let artifactory = Artifactory::from(
+        let artifactory = Artifactory::new(
             credentials
                 .artifactory
                 .wrap_err("Artifactory configuration is required")?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,8 +42,6 @@ async fn install() -> eyre::Result<()> {
     let credentials = Credentials::read().await?;
     let manifest = Manifest::read().await?;
 
-    let artifactory = Artifactory::new(credentials);
-
     let mut install = Vec::new();
 
     for dependency in manifest.dependencies {
@@ -60,7 +58,13 @@ async fn install() -> eyre::Result<()> {
             }
         }
 
-        install.push(PackageStore::install(dependency, artifactory.clone()));
+        let artifactory =
+            Artifactory::new(credentials.clone(), dependency.manifest.registry.clone());
+
+        install.push(PackageStore::install(
+            dependency.clone(),
+            artifactory.clone(),
+        ));
     }
 
     futures::future::try_join_all(install)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,61 +17,55 @@ pub mod registry;
 #[cfg(feature = "build")]
 pub use generator::Language;
 
+use credentials::Credentials;
+use eyre::{ContextCompat, WrapErr};
+use manifest::Manifest;
+use package::PackageStore;
+use registry::Artifactory;
+
 /// Cargo build integration for buffrs
 ///
 /// Important: Only use this inside of cargo build scripts!
 #[cfg(feature = "build")]
 pub fn build(language: Language) -> eyre::Result<()> {
-    use credentials::Credentials;
-    use eyre::ContextCompat;
-    use eyre::WrapErr;
-    use manifest::Manifest;
-    use package::PackageStore;
-    use registry::Artifactory;
-
     println!("cargo:rerun-if-changed={}", PackageStore::PROTO_VENDOR_PATH);
-
-    async fn install() -> eyre::Result<()> {
-        let credentials = Credentials::read().await?;
-
-        let artifactory = Artifactory::new(
-            credentials
-                .artifactory
-                .wrap_err("Artifactory configuration is required")?,
-        );
-
-        let manifest = Manifest::read().await?;
-
-        let mut install = Vec::new();
-
-        for dependency in manifest.dependencies {
-            if let Ok(pkg) = PackageStore::resolve(&dependency.package).await {
-                let pkg = pkg.package.wrap_err_with(|| {
-                    format!(
-                        "required package entry in manifest of {} to be present",
-                        dependency.package
-                    )
-                })?;
-
-                if dependency.manifest.version.matches(&pkg.version) {
-                    continue;
-                }
-            }
-
-            install.push(PackageStore::install(dependency, artifactory.clone()));
-        }
-
-        futures::future::try_join_all(install)
-            .await
-            .wrap_err("Failed to install missing dependencies")?;
-
-        Ok(())
-    }
 
     let rt = tokio::runtime::Runtime::new()?;
 
     rt.block_on(install())?;
     rt.block_on(generator::generate(language))?;
+
+    Ok(())
+}
+
+async fn install() -> eyre::Result<()> {
+    let credentials = Credentials::read().await?;
+    let manifest = Manifest::read().await?;
+
+    let artifactory = Artifactory::new(manifest.clone(), credentials);
+
+    let mut install = Vec::new();
+
+    for dependency in manifest.dependencies {
+        if let Ok(pkg) = PackageStore::resolve(&dependency.package).await {
+            let pkg = pkg.package.wrap_err_with(|| {
+                format!(
+                    "required package entry in manifest of {} to be present",
+                    dependency.package
+                )
+            })?;
+
+            if dependency.manifest.version.matches(&pkg.version) {
+                continue;
+            }
+        }
+
+        install.push(PackageStore::install(dependency, artifactory.clone()));
+    }
+
+    futures::future::try_join_all(install)
+        .await
+        .wrap_err("Failed to install missing dependencies")?;
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ async fn install() -> eyre::Result<()> {
     let credentials = Credentials::read().await?;
     let manifest = Manifest::read().await?;
 
-    let artifactory = Artifactory::new(manifest.clone(), credentials);
+    let artifactory = Artifactory::new(credentials);
 
     let mut install = Vec::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -358,7 +358,7 @@ mod cmd {
     /// Logs you in for a registry
     pub async fn login(mut credentials: Credentials, registry: RegistryUri) -> eyre::Result<()> {
         let token = {
-            tracing::info!("Please enter your artifactory token: ");
+            tracing::info!("Please enter your artifactory token:");
 
             let mut raw = String::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -307,8 +307,7 @@ mod cmd {
             }
         }
 
-        let manifest = Manifest::read().await?;
-        let artifactory = Artifactory::new(manifest, credentials);
+        let artifactory = Artifactory::new(credentials);
 
         let package = PackageStore::release()
             .await
@@ -327,7 +326,7 @@ mod cmd {
     /// Installs dependencies
     pub async fn install(credentials: Credentials) -> eyre::Result<()> {
         let manifest = Manifest::read().await?;
-        let artifactory = Artifactory::new(manifest.clone(), credentials);
+        let artifactory = Artifactory::new(credentials);
 
         let mut install = Vec::new();
 
@@ -372,8 +371,7 @@ mod cmd {
 
         credentials.insert(registry.clone(), token);
 
-        let manifest = Manifest::read().await?;
-        let artifactory = Artifactory::new(manifest, credentials.clone());
+        let artifactory = Artifactory::new(credentials.clone());
 
         if env::var("BUFFRS_TESTSUITE").is_err() {
             artifactory

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -3,7 +3,10 @@
 use eyre::Context;
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fmt};
+use std::{
+    collections::HashMap,
+    fmt::{self, Display},
+};
 use tokio::fs;
 
 use crate::package::{PackageId, PackageType};
@@ -117,18 +120,24 @@ pub struct Dependency {
 
 impl Dependency {
     /// Creates a new dependency
-    pub fn new(repository: String, package: PackageId, version: VersionReq) -> Self {
+    pub fn new(
+        registry: Registry,
+        repository: Repository,
+        package: PackageId,
+        version: VersionReq,
+    ) -> Self {
         Self {
             package,
             manifest: DependencyManifest {
                 repository,
                 version,
+                registry,
             },
         }
     }
 }
 
-impl fmt::Display for Dependency {
+impl Display for Dependency {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -144,5 +153,41 @@ pub struct DependencyManifest {
     /// Version requirement in the buffrs format, currently only supports pinning
     pub version: VersionReq,
     /// Artifactory repository to pull dependency from
-    pub repository: String,
+    pub repository: Repository,
+    /// Artifactory registry to pull from
+    pub registry: Registry,
+}
+
+#[derive(Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Registry(pub String);
+
+impl std::ops::Deref for Registry {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Display for Registry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[derive(Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Repository(pub String);
+
+impl std::ops::Deref for Repository {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Display for Repository {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
 }

--- a/src/registry/artifactory.rs
+++ b/src/registry/artifactory.rs
@@ -8,7 +8,7 @@ use url::Url;
 use super::Registry;
 use crate::{
     credentials::Credentials,
-    manifest::{Dependency, Manifest, RegistryUri, Repository},
+    manifest::{Dependency, RegistryUri, Repository},
     package::Package,
 };
 
@@ -16,14 +16,12 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct Artifactory {
     credentials: Arc<Credentials>,
-    manifest: Arc<Manifest>, // TODO kihehs: Can I remove this?
 }
 
 impl Artifactory {
-    pub fn new(manifest: Manifest, credentials: Credentials) -> Self {
+    pub fn new(credentials: Credentials) -> Self {
         Self {
             credentials: Arc::new(credentials),
-            manifest: Arc::new(manifest),
         }
     }
 

--- a/src/registry/local.rs
+++ b/src/registry/local.rs
@@ -6,7 +6,7 @@ use bytes::Bytes;
 use eyre::{ensure, ContextCompat};
 
 use crate::{
-    manifest::{Dependency, RegistryUri, Repository},
+    manifest::{Dependency, Repository},
     package::Package,
 };
 
@@ -71,12 +71,7 @@ impl Registry for LocalRegistry {
         Package::try_from(bytes)
     }
 
-    async fn publish(
-        &self,
-        registry: RegistryUri, // TODO @kihehs: When to use it?
-        package: Package,
-        repository: Repository,
-    ) -> eyre::Result<()> {
+    async fn publish(&self, package: Package, repository: Repository) -> eyre::Result<()> {
         let path = self.base_dir.join(PathBuf::from(format!(
             "{}/{}/{}-{}.tgz",
             repository, package.manifest.name, package.manifest.name, package.manifest.version,
@@ -129,13 +124,9 @@ mod tests {
         let package_bytes =
             Bytes::from(include_bytes!("../../tests/data/packages/test-api-0.1.0.tgz").to_vec());
 
-        let registry_uri = RegistryUri::from_str("http://some-registry/artifactory")
-            .expect("Failed to parse registry URL");
-
         // Publish to local registry and assert the tgz exists in the file system
         registry
             .publish(
-                registry_uri.clone(),
                 Package::new(manifest.clone(), package_bytes.clone()),
                 "test-repo".into(),
             )
@@ -148,6 +139,9 @@ mod tests {
             ),
             package_bytes
         );
+
+        let registry_uri = RegistryUri::from_str("http://some-registry/artifactory")
+            .expect("Failed to parse registry URL");
 
         // Download package from local registry and assert the tgz bytes and the metadata match what we
         // had published.

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -1,7 +1,7 @@
 // (c) Copyright 2023 Helsing GmbH. All rights reserved.
 
 use crate::{
-    manifest::{Dependency, RegistryUri, Repository},
+    manifest::{Dependency, Repository},
     package::Package,
 };
 
@@ -17,12 +17,7 @@ pub trait Registry {
     /// Downloads a package from the registry
     async fn download(&self, dependency: Dependency) -> eyre::Result<Package>;
     /// Publishes a package to the registry
-    async fn publish(
-        &self,
-        registry: RegistryUri,
-        package: Package,
-        repository: Repository,
-    ) -> eyre::Result<()>;
+    async fn publish(&self, package: Package, repository: Repository) -> eyre::Result<()>;
 }
 
 /// An enum containing all supported registries

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -1,7 +1,7 @@
 // (c) Copyright 2023 Helsing GmbH. All rights reserved.
 
 use crate::{
-    manifest::{Dependency, Repository},
+    manifest::{Dependency, RegistryUri, Repository},
     package::Package,
 };
 
@@ -9,7 +9,7 @@ mod artifactory;
 #[cfg(test)]
 mod local;
 
-pub use artifactory::{Artifactory, ArtifactoryConfig};
+pub use artifactory::Artifactory;
 
 /// A `buffrs` registry used for remote package management
 #[async_trait::async_trait]
@@ -17,7 +17,12 @@ pub trait Registry {
     /// Downloads a package from the registry
     async fn download(&self, dependency: Dependency) -> eyre::Result<Package>;
     /// Publishes a package to the registry
-    async fn publish(&self, package: Package, repository: Repository) -> eyre::Result<()>;
+    async fn publish(
+        &self,
+        registry: RegistryUri,
+        package: Package,
+        repository: Repository,
+    ) -> eyre::Result<()>;
 }
 
 /// An enum containing all supported registries

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -1,6 +1,9 @@
 // (c) Copyright 2023 Helsing GmbH. All rights reserved.
 
-use crate::{manifest::Dependency, package::Package};
+use crate::{
+    manifest::{Dependency, Repository},
+    package::Package,
+};
 
 mod artifactory;
 #[cfg(test)]
@@ -14,7 +17,7 @@ pub trait Registry {
     /// Downloads a package from the registry
     async fn download(&self, dependency: Dependency) -> eyre::Result<Package>;
     /// Publishes a package to the registry
-    async fn publish(&self, package: Package, repository: String) -> eyre::Result<()>;
+    async fn publish(&self, package: Package, repository: Repository) -> eyre::Result<()>;
 }
 
 /// An enum containing all supported registries

--- a/tests/cmd/add/mod.rs
+++ b/tests/cmd/add/mod.rs
@@ -6,6 +6,8 @@ fn fixture() {
 
     crate::cli!()
         .arg("add")
+        .arg("--registry")
+        .arg("http://my-reg.jfrog.io/artifactory")
         .arg("my-repository/my-package@=1.0.0")
         .current_dir(vfs.root())
         .assert()

--- a/tests/cmd/add/out/Proto.toml
+++ b/tests/cmd/add/out/Proto.toml
@@ -6,3 +6,4 @@ version = "0.0.1"
 [dependencies.my-package]
 version = "=1.0.0"
 repository = "my-repository"
+registry = "http://my-reg.jfrog.io/artifactory"

--- a/tests/cmd/login/mod.rs
+++ b/tests/cmd/login/mod.rs
@@ -6,7 +6,7 @@ fn fixture() {
 
     crate::cli!()
         .arg("login")
-        .arg("--url")
+        .arg("--registry")
         .arg("https://org.jfrog.io/artifactory")
         .current_dir(vfs.root())
         .write_stdin("some-token")

--- a/tests/cmd/login/out/$HOME/.buffrs/credentials.toml
+++ b/tests/cmd/login/out/$HOME/.buffrs/credentials.toml
@@ -1,3 +1,3 @@
-[artifactory]
-url = "https://org.jfrog.io/artifactory"
-password = "some-token"
+[[credentials]]
+uri = "https://org.jfrog.io/artifactory"
+token = "some-token"

--- a/tests/cmd/logout/mod.rs
+++ b/tests/cmd/logout/mod.rs
@@ -6,6 +6,8 @@ fn fixture() {
 
     crate::cli!()
         .arg("logout")
+        .arg("--registry")
+        .arg("https://org.jfrog.io/artifactory")
         .current_dir(vfs.root())
         .assert()
         .success()

--- a/tests/cmd/logout/out/$HOME/.buffrs/credentials.toml
+++ b/tests/cmd/logout/out/$HOME/.buffrs/credentials.toml
@@ -1,0 +1,1 @@
+credentials = []

--- a/tests/cmd/remove/in/Proto.toml
+++ b/tests/cmd/remove/in/Proto.toml
@@ -6,3 +6,4 @@ version = "0.0.1"
 [dependencies.my-package]
 version = "=1.0.0"
 repository = "my-repository"
+registry = "https://org.jfrog.io/artifactory"


### PR DESCRIPTION
This enables logging into and downloading protobufs from more than one registry.