### PR TITLE
Sync Cargo lockfile with manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ dependencies = [
 
 [[package]]
 name = "buffrs"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "assert_cmd",
  "assert_fs",


### PR DESCRIPTION
Fixes a small semantic issue with b5a38d9 due to the lockfile falling out of sync with the declared version in the Cargo manifest.