### PR TITLE
Clean up imports.

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 #[cfg(feature = "build")]
-use crate::{generator, generator::Language};
+use crate::generator::{Generator, Language};
 #[cfg(feature = "build")]
 use std::path::PathBuf;
 
@@ -281,7 +281,7 @@ pub async fn uninstall() -> miette::Result<()> {
 /// Generate bindings for a given language
 #[cfg(feature = "build")]
 pub async fn generate(language: Language, out_dir: PathBuf) -> miette::Result<()> {
-    generator::Generator::Protoc { language, out_dir }
+    Generator::Protoc { language, out_dir }
         .generate()
         .await
         .wrap_err(miette!("failed to generate {language} bindings"))

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -20,6 +20,7 @@ use std::{
 use miette::{ensure, miette, Context, IntoDiagnostic};
 use protoc_bin_vendored::protoc_bin_path;
 use serde::{Deserialize, Serialize};
+use tracing::{debug, info};
 
 use crate::{manifest::Manifest, package::PackageStore};
 
@@ -99,7 +100,7 @@ impl Generator {
 
                 protoc_cmd.args(&protos);
 
-                tracing::debug!(":: running {protoc_cmd:?}");
+                debug!(":: running {protoc_cmd:?}");
 
                 let output = protoc_cmd.output().await.into_diagnostic()?;
 
@@ -113,7 +114,7 @@ impl Generator {
                     String::from_utf8_lossy(&output.stderr)
                 );
 
-                tracing::info!(":: {language} code generated successfully");
+                info!(":: {language} code generated successfully");
             }
         }
 
@@ -126,7 +127,7 @@ impl Generator {
     pub async fn generate(&self) -> miette::Result<()> {
         let manifest = Manifest::read().await?;
 
-        tracing::info!(":: initializing code generator");
+        info!(":: initializing code generator");
 
         ensure!(
             manifest.package.kind.compilable() || !manifest.dependencies.is_empty(),
@@ -139,7 +140,7 @@ impl Generator {
 
         if manifest.package.kind.compilable() {
             let location = Path::new(PackageStore::PROTO_PATH);
-            tracing::info!(
+            info!(
                 ":: compiled {} [{}]",
                 manifest.package.name,
                 location.display()
@@ -148,7 +149,7 @@ impl Generator {
 
         for dependency in manifest.dependencies {
             let location = PackageStore::locate(&dependency.package);
-            tracing::info!(
+            info!(
                 ":: compiled {} [{}]",
                 dependency.package,
                 location.display()

--- a/src/registry/local.rs
+++ b/src/registry/local.rs
@@ -95,12 +95,13 @@ impl LocalRegistry {
 
 #[cfg(test)]
 mod tests {
-    use crate::manifest::{Dependency, Manifest, PackageManifest};
-    use crate::package::{Package, PackageType};
-    use crate::registry::local::LocalRegistry;
+    use crate::{
+        manifest::{Dependency, Manifest, PackageManifest},
+        package::{Package, PackageType},
+        registry::local::LocalRegistry,
+    };
     use bytes::Bytes;
-    use std::env;
-    use std::path::PathBuf;
+    use std::{env, path::PathBuf};
     use tokio::fs;
 
     #[tokio::test]

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -14,7 +14,7 @@
 
 use std::{
     fmt::{self, Display},
-    ops::DerefMut,
+    ops::{Deref, DerefMut},
     str::FromStr,
 };
 
@@ -41,7 +41,7 @@ impl From<RegistryUri> for Url {
     }
 }
 
-impl std::ops::Deref for RegistryUri {
+impl Deref for RegistryUri {
     type Target = Url;
 
     fn deref(&self) -> &Self::Target {


### PR DESCRIPTION
This commit "cleans up" the code base somewhat by making sure that types, functions and modules that are referred to multiple times in the code are properly imported, instead of referring to them by their absolute path.

To me, this makes code more readable. I like to keep visual noise to the minimum. There are some cases where it makes sense to use an absolute path multiple times, for example to make code less ambiguous. But for the most part, I try to avoid it.

## Unqualified vs qualified types

In Rust, we have the choice between using types in a qualified way:

```rust
fn do_something(client: reqwest::Client, method: http::Method, response: axum::request::Response) -> eyre::Result<serde_json::Value> {
  // ..
}
```

and using them in an unqualified way, after importing:

```rust
use reqwest::Client;
use http::Method;
use axum::request::Response;
use eyre::Result;
use serde_json::Value;

fn do_something(client: Client, method: Method, response: Response) -> Result<Value> {
  // ..
}
```

Both of these options produce valid code. I have some personal preferences for this, which kind of relate to my development workflow. I tend to (have) to read a lot of code, and as such I try to optimize for code that I find easy to read. 
I also tend to develop in the terminal, with a split pane, such that only half my screen is used for my editor of choice. 

With these two constraints, there comes some preferences:

- **Shorter lines of code are more legible for me** (< 80 or 100 lines, depending on terminal and screen)
- **Less repetition is better for me**. If I work in a file that talks to an HTTP API, then I know what the `Client` is, I do not need it spelled out as `reqwest::Client`. 

  On the other hand, if I'm reading in a file that handles a HTTP API and a database connection, then it might make sense to disambiguate the `postgres::Client` from the `reqwest::Client`. Although typically I would solve that by renaming the import, for example:
  
  ```rust
  use reqwest::Client as HttpClient;
  use postgres::Client as PostgresClient;
  ```

  <details>
  <summary>
  In the example code above it might be clearer to import <code>serde_json::Value</code> as <code>JsonValue</code>.

  </summary>

  In the example code above it might be clearer to import `serde_json::Value` as `JsonValue` if that is how it is used, because that way it more clearly communicates the intent (*this is a JSON value*) without being overly explicit (`serde_json::Value`), because when reading the code, I might not particularly care that it is a JSON value from the `serde_json` crate (as I can get that information easily from `rust-analyzer`), I just care about the meaning of this type, which is to hold arbitrary parsed JSON data.

  </details>

As a result of this, my personal preference is that when in doubt, I will import things. I will always explicitly import things if they are used multiple times in the same file. Sometimes, I will import things and rename them to make it more clear.

> When in doubt, prefer brevity over explicitness.

There is one thing to note here: A lot of people use VSCode with `rust-analyzer`. The default setup for this will show the full, qualified path for types. So, if you are used to using VSCode or other IDEs, you will not really notice a difference between writing `Client` versus `reqwest::Client`, because VSCode will show you the `reqwest::` path anyways (in gray). This means that if you are used to VSCode, you may tend to write out the full, unqualified paths just because you are used to reading code that way. VSCode can be told to not show the full paths unless you are hovering over them, if you want to try that. I do feel that there is still a benefit from keeping code short, even if it does not make a difference to some.

## Error handling

When using error handling libraries such as `anyhow` or `eyre`, I tend to import their `Result` type and use that in an unqualified way (as in, use `Result<T>` rather than `eyre::Result<T>`). 

Why? In those crates, [Result](https://docs.rs/eyre/latest/eyre/type.Result.html) is defined as:

```rust
pub type Result<T, E = eyre::Report> = std::result::Result<T, E>;
```

This means that `eyre::Result<T>` is just an `std::result::Result<T, E>` with the `E` defaulting to `eyre::Report`. For that reason, importing `eyre::Result` and using it as `Result` is fine, since you can always override the error type. In other words, `eyre::Result<A, B>` and `std::result::Result<A, B>` are equivalent, the only different with the `eyre` version is that if you do not specify the error type, it falls back to being an `eyre::Report`.

```rust
use eyre::Result;
use std::io::Error as IoError;

// returns eyre::Result<String>
fn my_name() -> Result<String> {
  Ok("Name".into())
}

// returns an `std::result::Result<String, std::io::Error>`
fn do_io() -> Result<String, IoError> {
  std::fs::read_to_string("/etc/passwd")
}
```

Since projects typically do not mix and match several error handling libraries in the same crate, whenever you see `Result<T>` it is immediately obvious that this will be an `eyre` result, or whichever error handling library the current project uses. So writing out `eyre::Result` does not add any necessary context for understanding the code, unless perhaps there are multiple error libraries in use in the current file.

## Logging

In general, glob imports are discouraged a little bit, it is always nice to not use them so that it is immediately obvious what comes from where. For that reason, there is a [clippy lint](https://rust-lang.github.io/rust-clippy/master/index.html#/wildcard_imports) that can be used to disallow using glob imports. 

Logging or tracing is the one thing where I feel it can make sense to do a glob import:

```rust
use tracing::*;

fn do_something() {
    info!("Hello");
}
```

The reason is that:

- You don't want to clutter the codebase with `tracing::`. Tracing or logging statements should be short and sweet. There is nothing shorter and sweeter than `info!("XYZ")`. 
- You just want to be able to drop an `info!(...)` anywhere in the code and expect it to work, and not have to edit the import to add `info` to the list because you had only imported `{debug, error}` before.
- This makes switching between the `log` crate and the `tracing` crate easy, as they both have similar macros.

## Deriving Traits

In the PR, I have also removed implementations of [`PartialOrd`](https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html) and [`Ord`](https://doc.rust-lang.org/std/cmp/trait.Ord.html) and replaced them with derives. I believe that they were maybe added in error, because it was not know that they could be derived automatically.

My rule of thumb is:

- If a trait can be derived automatically, it must be derived automatically. Less code is better.
- If a trait can be derived automatically, but it has constraints that make it so it needs to be done manually, perhaps because a specific ordering is desired, then it needs to be clearly communicated with a comment explaining that this is deliberately implemented manually, and outlining the reason for it. It should also come with accompanying unit tests to ensure that this is not accidentally refactored.

## Other notes

Note that this PR includes strong (personal) opinions, which you may or may not agree with. A part of the reason for creating this PR is to spark a conversation about coding styles and preferences, so feel free to chime in and tell me why I'm wrong! Also feel free to close this. Writing up these style preferences is a lot of fun, makes you think about what preferences you have and why you might have them.

I hope this all makes sense