### PR TITLE
Switch from TryFrom to FromStr for Manifest

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -90,7 +90,7 @@ impl Manifest {
             .await
             .wrap_err("Failed to read manifest")?;
 
-        let raw: RawManifest = toml::from_str(&toml).wrap_err("Failed to parse manifest")?;
+        let raw: RawManifest = toml.parse().wrap_err("Failed to parse manifest")?;
 
         Ok(raw.into())
     }
@@ -127,7 +127,7 @@ impl FromStr for Manifest {
     type Err = toml::de::Error;
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
-        RawManifest::from_str(input).map(Self::from)
+        input.parse::<RawManifest>().map(Self::from)
     }
 }
 

--- a/src/package.rs
+++ b/src/package.rs
@@ -121,9 +121,9 @@ impl PackageStore {
             "Failed to locate local manifest for package: {package}"
         ))?;
 
-        Manifest::from_str(&manifest)
+        manifest
+            .parse()
             .wrap_err(format!("Malformed manifest of package {package}"))
-            .map(Manifest::from)
     }
 
     /// Packages a release from the local file system state
@@ -334,7 +334,8 @@ impl TryFrom<Bytes> for Package {
             .wrap_err("Failed to find manifest in package")?;
 
         let manifest = manifest.bytes().collect::<io::Result<Vec<_>>>()?;
-        let manifest = Manifest::from_str(&String::from_utf8(manifest)?)
+        let manifest = String::from_utf8(manifest)?
+            .parse()
             .wrap_err("Failed to parse manifest")?;
 
         Ok(Self { manifest, tgz })

--- a/src/registry/local.rs
+++ b/src/registry/local.rs
@@ -105,10 +105,8 @@ mod tests {
     use crate::manifest::{Dependency, Manifest, PackageManifest};
     use crate::package::{Package, PackageType};
     use crate::registry::local::LocalRegistry;
-    use crate::registry::RegistryUri;
     use bytes::Bytes;
     use std::path::PathBuf;
-    use std::str::FromStr;
     use std::{env, fs};
 
     #[tokio::test]
@@ -145,7 +143,8 @@ mod tests {
             package_bytes
         );
 
-        let registry_uri = RegistryUri::from_str("http://some-registry/artifactory")
+        let registry_uri = "http://some-registry/artifactory"
+            .parse()
             .expect("Failed to parse registry URL");
 
         // Download package from local registry and assert the tgz bytes and the metadata match what we


### PR DESCRIPTION
This PR changes `Manifest` and `RawManifest` to implement the [`FromStr`](https://doc.rust-lang.org/stable/std/str/trait.FromStr.html) trait rather than the [`TryFrom<String>`](https://doc.rust-lang.org/stable/std/convert/trait.TryFrom.html) trait.

While both traits can be used and do achieve a similar purpose, there is one important difference in their semantics related to what they do with the string they are taking:

- The `TryFrom<String>` attempts to consume a `String` and convert it into the target type (`Manifest` or `RawManifest`). The ownership of the `String` is thereby moved during the conversion. This is therefore useful if you do need ownership of the input type.
- The `FromStr` trait attempts to parse a `&str` (reference to a string) into the target type (`Manifest` or `RawManifest`). It does not take ownership of the string, only a read-only reference to it. This is therefore useful if you only need to read the input string.

Since fundamentally, are are just parsing a string and we do not need it anymore after the parsing operation, the `FromStr` trait is more useful here because it does not require us to consume to the string. The `TryFrom<String>` trait would be more appropriate if we wanted to hold on to the original string after the parsing operation, and perhaps store that inside the `Manifest` type. 

But since we simply discard the string, there is no good reason to use `TryFrom`. For this reason, this PR changes the code base to use `FromStr` instead.
