### PR TITLE
Credentials storage XDG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,13 +193,13 @@ dependencies = [
  "bytes",
  "clap",
  "color-eyre",
+ "dirs",
  "eyre",
  "flate2",
  "fs_extra",
  "futures",
  "git2",
  "hex",
- "home",
  "human-panic",
  "predicates",
  "pretty_assertions",
@@ -358,6 +358,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,7 +450,7 @@ checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "windows-sys",
 ]
 
@@ -1043,6 +1064,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "os_info"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,7 +1110,7 @@ checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "smallvec",
  "windows-targets",
 ]
@@ -1297,11 +1324,31 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall 0.2.16",
+ "thiserror",
 ]
 
 [[package]]
@@ -1677,7 +1724,7 @@ checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix",
  "windows-sys",
 ]
@@ -1687,6 +1734,26 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
+name = "thiserror"
+version = "1.0.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "thread_local"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ flate2 = "1"
 futures = "0.3"
 git2 = { version = "0.18.1", optional = true }
 hex = "0.4.3"
-home = "0.5.5"
 human-panic = "1"
 protoc-bin-vendored = { version = "3.0.0", optional = true }
 ring = "0.16"
@@ -52,6 +51,7 @@ tracing-subscriber = "0.3"
 url = { version = "2.4", features = ["serde"] }
 walkdir = "2"
 async-recursion = "1.0.5"
+dirs = "5.0.1"
 
 [dependencies.reqwest]
 version = "0.11"

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -76,10 +76,8 @@ impl Credentials {
             .wrap_err("Failed to write credentials")
     }
 
-    /// Loads the credentials from the file system
-    ///
-    /// Note: Initializes the credential file if its not present
-    pub async fn load() -> eyre::Result<Self> {
+    /// Loads the credentials from the file system, or creates default if not present.
+    pub async fn load_or_init() -> eyre::Result<Self> {
         let Ok(credentials) = Self::read().await else {
             let credentials = Credentials::default();
             credentials.write().await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,7 +137,7 @@ async fn main() -> eyre::Result<()> {
         .unwrap();
 
     let cli = Cli::parse();
-    let credentials = Credentials::load().await?;
+    let credentials = Credentials::load_or_init().await?;
 
     match cli.command {
         Command::Init { lib, api, package } => {


### PR DESCRIPTION
See #108.

This PR switches the code used for reading and writing credentials to being XDG-compatible, but also backwards-compatible.

It does that by having a list of candidate paths for the configuration that it checks, preferring the XDG-compatible path but falling back to the previous path. When writing, it will only write to the XDG-compatible path.

This PR is still a draft.