### PR TITLE
Skip serializing empty credentials vector in credentials file.

### DIFF
--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -93,6 +93,7 @@ impl Credentials {
 /// Credential store for storing authentication data. Serialization type.
 #[derive(Serialize, Deserialize)]
 struct RawCredentialCollection {
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     credentials: Vec<RawRegistryCredentials>,
 }
 

--- a/tests/cmd/logout/out/$HOME/.buffrs/credentials.toml
+++ b/tests/cmd/logout/out/$HOME/.buffrs/credentials.toml
@@ -1,1 +1,0 @@
-credentials = []


### PR DESCRIPTION
Closes #65.

This adds two annotations for the `credentials` field of `RawCredentialsCollection`. The `skip_serializing_if` annotation tells serde to not emit this if the array is empty, while the `default` annotation tells serde to assume it is empty when it does not find a credentials entry during deserializing.