### PR TITLE
Async correctness for buildsrs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,12 +662,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,16 +915,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
 
 [[package]]
-name = "lock_api"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,16 +984,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "object"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1064,29 +1038,6 @@ name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -1474,12 +1425,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1723,8 +1668,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "num_cpus",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ serde = { version = "1", features = ["derive"] }
 serde_typename = "0.1"
 semver = { version = "1", features = ["serde"] }
 tar = "0.4"
-tokio = { version = "1", features = ["full", "tracing"] }
+tokio = { version = "1", features = ["fs", "rt", "macros", "process", "io-std", "tracing"] }
 toml = "0.8.0"
 tonic-build = { version = "0.10.0", optional = true }
 tracing = "0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,7 +120,7 @@ enum Command {
     },
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> eyre::Result<()> {
     human_panic::setup_panic!();
 

--- a/src/registry/local.rs
+++ b/src/registry/local.rs
@@ -16,6 +16,7 @@ use std::path::PathBuf;
 
 use bytes::Bytes;
 use eyre::{ensure, ContextCompat};
+use tokio::fs;
 
 use crate::{manifest::Dependency, package::Package};
 
@@ -71,7 +72,7 @@ impl LocalRegistry {
 
         tracing::debug!("downloaded dependency {dependency} from {:?}", path);
 
-        let bytes = Bytes::from(std::fs::read(path)?);
+        let bytes = Bytes::from(fs::read(path).await?);
         Package::try_from(bytes)
     }
 
@@ -84,9 +85,9 @@ impl LocalRegistry {
             package.version(),
         )));
 
-        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::create_dir_all(path.parent().unwrap()).await?;
 
-        std::fs::write(&path, &package.tgz)?;
+        fs::write(&path, &package.tgz).await?;
 
         tracing::info!(
             ":: published {}/{}@{} to {:?}",


### PR DESCRIPTION
This PR addresses three things (mostly low-hanging fruit):

## Async Enforcement

Replace all usage of blocking APIs (`std::fs::*`, `std::io::*`) with their nonblocking counterparts (`tokio::fs::*`, `tokio::io::*`). There is currently no way to enforce this through the compiler, but we should do our best to ensure we don't call any blocking code. 

## Tokio feature pruning

Reduces the `tokio` dependencies to what is needed. This mostly just speeds up compile and link times marginally. We have enabled all the fun parts anyways, except we have disabled `rt-multi-thread` because we do not need it.

## Switch executor

Switch from using the default `multi_thread` executor to the `current_thread executor`. Why is this important? The default executor uses a thread-per-core model. Which means that if you launch buffrs on a large Ryzen with 128 cores, we'll launch 128 threads. We don't need that many threads. We are not compute-bound, but rather network and I/O bound. For that reason, keeping is single-threaded is the most reasonable thing to do for a CLI. 