### PR TITLE
Refactors `src/package.rs`

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -147,7 +147,11 @@ pub async fn remove(package: PackageName) -> miette::Result<()> {
 
 /// Packages the api and writes it to the filesystem
 pub async fn package(directory: impl AsRef<Path>, dry_run: bool) -> miette::Result<()> {
-    let package = PackageStore::current().into_diagnostic()?.release().await?;
+    let manifest = Manifest::read().await?;
+    let package = PackageStore::current()
+        .into_diagnostic()?
+        .release(manifest)
+        .await?;
 
     let path = directory.as_ref().join(format!(
         "{}-{}.tgz",
@@ -196,7 +200,11 @@ pub async fn publish(
 
     let artifactory = Artifactory::new(registry, &credentials)?;
 
-    let package = PackageStore::current().into_diagnostic()?.release().await?;
+    let manifest = Manifest::read().await?;
+    let package = PackageStore::current()
+        .into_diagnostic()?
+        .release(manifest)
+        .await?;
 
     if dry_run {
         tracing::warn!(":: aborting upload due to dry run");

--- a/src/command.rs
+++ b/src/command.rs
@@ -54,6 +54,7 @@ pub async fn init(kind: PackageType, name: Option<PackageName>) -> miette::Resul
             .to_str()
             .ok_or_else(|| miette!("current directory path is not valid utf-8"))?
             .parse()
+            .into_diagnostic()
     }
 
     let name = name.map(Result::Ok).unwrap_or_else(curr_dir_name)?;
@@ -97,6 +98,7 @@ pub async fn add(registry: RegistryUri, dependency: &str) -> miette::Result<()> 
 
     let package = package
         .parse::<PackageName>()
+        .into_diagnostic()
         .wrap_err(miette!("invalid package name: {package}"))?;
 
     let version = version

--- a/src/command.rs
+++ b/src/command.rs
@@ -16,8 +16,9 @@ use crate::{
     credentials::Credentials,
     lock::{LockedPackage, Lockfile},
     manifest::{Dependency, Manifest, PackageManifest, MANIFEST_FILE},
-    package::{DependencyGraph, PackageName, PackageStore, PackageType},
+    package::{PackageName, PackageStore, PackageType},
     registry::{Artifactory, RegistryUri},
+    resolver::DependencyGraph,
 };
 
 #[cfg(feature = "build")]

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -63,7 +63,7 @@ impl Generator {
 
         std::env::set_var("PROTOC", protoc.clone());
 
-        let store = PackageStore::current().into_diagnostic()?;
+        let store = PackageStore::current()?;
         let protos = store.collect(&store.proto_path()).await;
         let includes = &[store.proto_path()];
 
@@ -123,7 +123,7 @@ impl Generator {
     /// Execute code generation with pre-configured parameters
     pub async fn generate(&self) -> miette::Result<()> {
         let manifest = Manifest::read().await?;
-        let store = PackageStore::current().into_diagnostic()?;
+        let store = PackageStore::current()?;
 
         info!(":: initializing code generator");
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -130,7 +130,7 @@ impl Generator {
         info!(":: initializing code generator");
 
         ensure!(
-            manifest.package.kind.compilable() || !manifest.dependencies.is_empty(),
+            manifest.package.kind.is_compilable() || !manifest.dependencies.is_empty(),
             "either a compilable package (library or api) or at least one dependency is needed to generate code bindings."
         );
 
@@ -138,7 +138,7 @@ impl Generator {
             .await
             .wrap_err(miette!("failed to generate bindings"))?;
 
-        if manifest.package.kind.compilable() {
+        if manifest.package.kind.is_compilable() {
             let location = Path::new(PackageStore::PROTO_PATH);
             info!(
                 ":: compiled {} [{}]",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,9 +48,14 @@ pub mod resolver;
 #[tokio::main(flavor = "current_thread")]
 pub async fn build() -> miette::Result<()> {
     use credentials::Credentials;
+    use miette::IntoDiagnostic;
     use package::PackageStore;
 
-    println!("cargo:rerun-if-changed={}", PackageStore::PROTO_VENDOR_PATH);
+    let store = PackageStore::current().into_diagnostic()?;
+    println!(
+        "cargo:rerun-if-changed={}",
+        store.proto_vendor_path().display()
+    );
 
     let credentials = Credentials::read().await?;
     command::install(credentials).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,8 @@ pub mod manifest;
 pub mod package;
 /// Supported registries
 pub mod registry;
+/// Resolve package dependencies.
+pub mod resolver;
 
 /// Cargo build integration for buffrs
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,10 +48,9 @@ pub mod resolver;
 #[tokio::main(flavor = "current_thread")]
 pub async fn build() -> miette::Result<()> {
     use credentials::Credentials;
-    use miette::IntoDiagnostic;
     use package::PackageStore;
 
-    let store = PackageStore::current().into_diagnostic()?;
+    let store = PackageStore::current()?;
     println!(
         "cargo:rerun-if-changed={}",
         store.proto_vendor_path().display()

--- a/src/package.rs
+++ b/src/package.rs
@@ -163,9 +163,7 @@ impl PackageStore {
     }
 
     /// Packages a release from the local file system state
-    pub async fn release(&self) -> miette::Result<Package> {
-        let manifest = Manifest::read().await?;
-
+    pub async fn release(&self, manifest: Manifest) -> miette::Result<Package> {
         ensure!(
             manifest.package.kind.is_publishable(),
             "packages with type `impl` cannot be published"

--- a/src/package.rs
+++ b/src/package.rs
@@ -416,7 +416,10 @@ impl FromStr for PackageType {
 
 impl fmt::Display for PackageType {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", serde_typename::to_str(self).unwrap_or_default())
+        match serde_typename::to_str(self) {
+            Ok(value) => f.write_str(value),
+            Err(_error) => unreachable!(),
+        }
     }
 }
 

--- a/src/package.rs
+++ b/src/package.rs
@@ -230,18 +230,6 @@ impl PackageStore {
     }
 }
 
-#[test]
-fn can_get_proto_path() {
-    assert_eq!(
-        PackageStore::new("/tmp".into()).proto_path(),
-        PathBuf::from("/tmp/proto")
-    );
-    assert_eq!(
-        PackageStore::new("/tmp".into()).proto_vendor_path(),
-        PathBuf::from("/tmp/proto/vendor")
-    );
-}
-
 /// An in memory representation of a `buffrs` package
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Package {
@@ -443,35 +431,6 @@ impl fmt::Display for PackageType {
     }
 }
 
-#[test]
-fn can_check_publishable() {
-    assert!(PackageType::Lib.is_publishable());
-    assert!(PackageType::Api.is_publishable());
-    assert!(!PackageType::Impl.is_publishable());
-}
-
-#[test]
-fn can_check_compilable() {
-    assert!(PackageType::Lib.is_compilable());
-    assert!(PackageType::Api.is_compilable());
-    assert!(!PackageType::Impl.is_compilable());
-}
-
-#[test]
-fn can_default_package_type() {
-    assert_eq!(PackageType::default(), PackageType::Impl);
-}
-
-#[test]
-fn can_parse_package_type() {
-    let types = [PackageType::Lib, PackageType::Api, PackageType::Impl];
-    for typ in &types {
-        let string = typ.to_string();
-        let parsed: PackageType = string.parse().unwrap();
-        assert_eq!(parsed, *typ);
-    }
-}
-
 /// A `buffrs` package name for parsing and type safety
 #[derive(Clone, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Debug)]
 #[serde(try_from = "String", into = "String")]
@@ -542,20 +501,6 @@ impl PackageName {
     }
 }
 
-#[test]
-fn can_parse_package_name() {
-    assert_eq!(PackageName::new("abc"), Ok(PackageName("abc".into())));
-    assert_eq!(PackageName::new("a"), Err(PackageNameError::Length(1)));
-    assert_eq!(
-        PackageName::new("4abc"),
-        Err(PackageNameError::InvalidStart('4'))
-    );
-    assert_eq!(
-        PackageName::new("serde_typename"),
-        Err(PackageNameError::InvalidCharacter('_', 5))
-    );
-}
-
 impl TryFrom<String> for PackageName {
     type Error = PackageNameError;
 
@@ -589,5 +534,65 @@ impl Deref for PackageName {
 impl fmt::Display for PackageName {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_parse_package_name() {
+        assert_eq!(PackageName::new("abc"), Ok(PackageName("abc".into())));
+        assert_eq!(PackageName::new("a"), Err(PackageNameError::Length(1)));
+        assert_eq!(
+            PackageName::new("4abc"),
+            Err(PackageNameError::InvalidStart('4'))
+        );
+        assert_eq!(
+            PackageName::new("serde_typename"),
+            Err(PackageNameError::InvalidCharacter('_', 5))
+        );
+    }
+
+    #[test]
+    fn can_get_proto_path() {
+        assert_eq!(
+            PackageStore::new("/tmp".into()).proto_path(),
+            PathBuf::from("/tmp/proto")
+        );
+        assert_eq!(
+            PackageStore::new("/tmp".into()).proto_vendor_path(),
+            PathBuf::from("/tmp/proto/vendor")
+        );
+    }
+
+    #[test]
+    fn can_check_publishable() {
+        assert!(PackageType::Lib.is_publishable());
+        assert!(PackageType::Api.is_publishable());
+        assert!(!PackageType::Impl.is_publishable());
+    }
+
+    #[test]
+    fn can_check_compilable() {
+        assert!(PackageType::Lib.is_compilable());
+        assert!(PackageType::Api.is_compilable());
+        assert!(!PackageType::Impl.is_compilable());
+    }
+
+    #[test]
+    fn can_default_package_type() {
+        assert_eq!(PackageType::default(), PackageType::Impl);
+    }
+
+    #[test]
+    fn can_parse_package_type() {
+        let types = [PackageType::Lib, PackageType::Api, PackageType::Impl];
+        for typ in &types {
+            let string = typ.to_string();
+            let parsed: PackageType = string.parse().unwrap();
+            assert_eq!(parsed, *typ);
+        }
     }
 }

--- a/src/package.rs
+++ b/src/package.rs
@@ -309,7 +309,7 @@ impl Package {
     }
 
     /// Load a package from a precompressed archive.
-    pub fn load(tgz: Bytes) -> miette::Result<Self> {
+    fn parse(tgz: Bytes) -> miette::Result<Self> {
         let mut tar = Vec::new();
 
         let mut gz = flate2::read::GzDecoder::new(tgz.clone().reader());
@@ -381,7 +381,7 @@ impl TryFrom<Bytes> for Package {
     type Error = miette::Report;
 
     fn try_from(tgz: Bytes) -> Result<Self, Self::Error> {
-        Package::load(tgz)
+        Package::parse(tgz)
     }
 }
 

--- a/src/package.rs
+++ b/src/package.rs
@@ -467,27 +467,11 @@ impl TryFrom<String> for PackageName {
     }
 }
 
-impl TryFrom<&str> for PackageName {
-    type Error = miette::Report;
-
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        Self::try_from(value.to_string())
-    }
-}
-
-impl TryFrom<&String> for PackageName {
-    type Error = miette::Report;
-
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
-        Self::try_from(value.to_owned())
-    }
-}
-
 impl FromStr for PackageName {
     type Err = miette::Report;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Self::try_from(s)
+        Self::try_from(s.to_string())
     }
 }
 

--- a/src/package.rs
+++ b/src/package.rs
@@ -54,8 +54,8 @@ impl PackageStore {
     }
 
     /// Open current directory.
-    pub fn current() -> Result<Self, io::Error> {
-        Ok(Self::new(current_dir()?))
+    pub fn current() -> miette::Result<Self> {
+        Ok(Self::new(current_dir().into_diagnostic()?))
     }
 
     /// Open given directory.
@@ -510,10 +510,10 @@ impl TryFrom<String> for PackageName {
 }
 
 impl FromStr for PackageName {
-    type Err = PackageNameError;
+    type Err = miette::Report;
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
-        Self::new(input)
+        Self::new(input).into_diagnostic()
     }
 }
 

--- a/src/package.rs
+++ b/src/package.rs
@@ -91,8 +91,7 @@ impl PackageStore {
 
         let mut tar = tar::Archive::new(Bytes::from(tar).reader());
 
-        let pkg_dir =
-            Path::new(Self::PROTO_VENDOR_PATH).join(package.manifest.package.name.as_str());
+        let pkg_dir = Path::new(Self::PROTO_VENDOR_PATH).join(&*package.manifest.package.name);
 
         fs::remove_dir_all(&pkg_dir).await.ok();
 
@@ -126,7 +125,7 @@ impl PackageStore {
 
     /// Uninstalls a package from the local file system
     pub async fn uninstall(package: &PackageName) -> miette::Result<()> {
-        let pkg_dir = Path::new(Self::PROTO_VENDOR_PATH).join(package.as_str());
+        let pkg_dir = Path::new(Self::PROTO_VENDOR_PATH).join(&**package);
 
         fs::remove_dir_all(&pkg_dir)
             .await
@@ -265,7 +264,7 @@ impl PackageStore {
 
     /// Directory for the vendored installation of a package
     pub fn locate(package: &PackageName) -> PathBuf {
-        PathBuf::from(Self::PROTO_VENDOR_PATH).join(package.as_str())
+        PathBuf::from(Self::PROTO_VENDOR_PATH).join(&**package)
     }
 
     /// Collect .proto files in a given path whilst excluding vendored ones
@@ -538,7 +537,7 @@ impl From<PackageName> for String {
 }
 
 impl Deref for PackageName {
-    type Target = String;
+    type Target = str;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/package.rs
+++ b/src/package.rs
@@ -373,12 +373,6 @@ impl TryFrom<Bytes> for Package {
     }
 }
 
-impl From<&Package> for Bytes {
-    fn from(value: &Package) -> Self {
-        value.tgz.clone()
-    }
-}
-
 /// Package types
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Default)]
 #[serde(rename_all = "snake_case")]

--- a/src/package.rs
+++ b/src/package.rs
@@ -64,9 +64,7 @@ impl PackageStore {
 
         Ok(())
     }
-}
 
-impl PackageStore {
     /// Clears all packages from the file system
     pub async fn clear() -> miette::Result<()> {
         match fs::remove_dir_all(Self::PROTO_VENDOR_PATH).await {
@@ -80,9 +78,7 @@ impl PackageStore {
             )),
         }
     }
-}
 
-impl PackageStore {
     /// Unpacks a package into a local directory
     pub async fn unpack(package: &Package) -> miette::Result<()> {
         let mut tar = Vec::new();
@@ -127,9 +123,7 @@ impl PackageStore {
 
         Ok(())
     }
-}
 
-impl PackageStore {
     /// Uninstalls a package from the local file system
     pub async fn uninstall(package: &PackageName) -> miette::Result<()> {
         let pkg_dir = Path::new(Self::PROTO_VENDOR_PATH).join(package.as_str());
@@ -146,9 +140,7 @@ impl PackageStore {
             .await
             .wrap_err(miette!("failed to resolve package {package}"))
     }
-}
 
-impl PackageStore {
     /// Packages a release from the local file system state
     pub async fn release() -> miette::Result<Package> {
         let manifest = Manifest::read().await?;

--- a/src/package.rs
+++ b/src/package.rs
@@ -380,7 +380,7 @@ impl From<&Package> for Bytes {
 }
 
 /// Package types
-#[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum PackageType {
     /// A library package containing primitive type definitions
@@ -390,6 +390,7 @@ pub enum PackageType {
     /// An implementation package that implements an api or library
     ///
     /// Note: Implementation packages can't be published via Buffrs
+    #[default]
     Impl,
 }
 
@@ -416,12 +417,6 @@ impl FromStr for PackageType {
 impl fmt::Display for PackageType {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", serde_typename::to_str(self).unwrap_or_default())
-    }
-}
-
-impl Default for PackageType {
-    fn default() -> Self {
-        Self::Impl
     }
 }
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,0 +1,205 @@
+use std::{collections::HashMap, sync::Arc};
+
+use async_recursion::async_recursion;
+use miette::{ensure, Context, Diagnostic};
+use semver::VersionReq;
+use thiserror::Error;
+
+use crate::{
+    credentials::Credentials,
+    lock::Lockfile,
+    manifest::{Dependency, Manifest},
+    package::{Package, PackageName},
+    registry::{Artifactory, RegistryUri},
+};
+
+/// Represents a dependency contextualized by the current dependency graph
+pub struct ResolvedDependency {
+    /// The materialized package as downloaded from the registry
+    pub package: Package,
+    /// The registry the package was downloaded from
+    pub registry: RegistryUri,
+    /// The repository in the registry where the package can be found
+    pub repository: String,
+    /// Packages that requested this dependency (and what versions they accept)
+    pub dependants: Vec<Dependant>,
+    /// Transitive dependencies
+    pub depends_on: Vec<PackageName>,
+}
+
+/// Represents a requester of the associated dependency
+pub struct Dependant {
+    /// Package that requested the dependency
+    pub name: PackageName,
+    /// Version requirement
+    pub version_req: VersionReq,
+}
+
+/// Represents direct and transitive dependencies of the root package
+pub struct DependencyGraph {
+    entries: HashMap<PackageName, ResolvedDependency>,
+}
+
+#[derive(Error, Diagnostic, Debug)]
+#[error("failed to download dependency {name}@{version} from the registry")]
+struct DownloadError {
+    name: PackageName,
+    version: VersionReq,
+}
+
+impl DependencyGraph {
+    /// Recursively resolves dependencies from the manifest to build a dependency graph
+    pub async fn from_manifest(
+        manifest: &Manifest,
+        lockfile: &Lockfile,
+        credentials: &Arc<Credentials>,
+    ) -> miette::Result<Self> {
+        let name = manifest.package.name.clone();
+
+        let mut entries = HashMap::new();
+
+        for dependency in &manifest.dependencies {
+            Self::process_dependency(
+                name.clone(),
+                dependency.clone(),
+                true,
+                lockfile,
+                credentials,
+                &mut entries,
+            )
+            .await?;
+        }
+
+        Ok(Self { entries })
+    }
+
+    #[async_recursion]
+    async fn process_dependency(
+        name: PackageName,
+        dependency: Dependency,
+        is_root: bool,
+        lockfile: &Lockfile,
+        credentials: &Arc<Credentials>,
+        entries: &mut HashMap<PackageName, ResolvedDependency>,
+    ) -> miette::Result<()> {
+        let version_req = dependency.manifest.version.clone();
+        if let Some(entry) = entries.get_mut(&dependency.package) {
+            ensure!(
+                version_req.matches(entry.package.version()),
+                "a dependency of your project requires {}@{} which collides with {}@{} required by {}", 
+                    dependency.package,
+                    dependency.manifest.version,
+                    entry.dependants[0].name.clone(),
+                    dependency.manifest.version,
+                    entry.package.manifest.package.version.clone(),
+            );
+
+            entry.dependants.push(Dependant { name, version_req });
+        } else {
+            let dependency_pkg =
+                Self::resolve(dependency.clone(), is_root, lockfile, credentials).await?;
+
+            let dependency_name = dependency_pkg.name().clone();
+            let sub_dependencies = dependency_pkg.manifest.dependencies.clone();
+            let sub_dependency_names: Vec<_> = sub_dependencies
+                .iter()
+                .map(|sub_dependency| sub_dependency.package.clone())
+                .collect();
+
+            entries.insert(
+                dependency_name.clone(),
+                ResolvedDependency {
+                    package: dependency_pkg,
+                    registry: dependency.manifest.registry,
+                    repository: dependency.manifest.repository,
+                    dependants: vec![Dependant { name, version_req }],
+                    depends_on: sub_dependency_names,
+                },
+            );
+
+            for sub_dependency in sub_dependencies {
+                Self::process_dependency(
+                    dependency_name.clone(),
+                    sub_dependency,
+                    false,
+                    lockfile,
+                    credentials,
+                    entries,
+                )
+                .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn resolve(
+        dependency: Dependency,
+        is_root: bool,
+        lockfile: &Lockfile,
+        credentials: &Arc<Credentials>,
+    ) -> miette::Result<Package> {
+        if let Some(local_locked) = lockfile.get(&dependency.package) {
+            ensure!(
+                dependency.manifest.version.matches(&local_locked.version),
+                "dependency {} cannot be satisfied - requested {}, but version {} is locked",
+                dependency.package,
+                dependency.manifest.version,
+                local_locked.version,
+            );
+
+            ensure!(
+                is_root || dependency.manifest.registry == local_locked.registry,
+                "mismatched registry detected for dependency {} - requested {} but lockfile requires {}",
+                    dependency.package,
+                    dependency.manifest.registry,
+                    local_locked.registry,
+            );
+
+            let registry = Artifactory::new(dependency.manifest.registry.clone(), credentials)
+                .wrap_err(DownloadError {
+                    name: dependency.package.clone(),
+                    version: dependency.manifest.version.clone(),
+                })?;
+
+            let package = registry
+                .download(dependency.with_version(&local_locked.version))
+                .await
+                .wrap_err(DownloadError {
+                    name: dependency.package,
+                    version: dependency.manifest.version,
+                })?;
+
+            local_locked.validate(&package)?;
+
+            Ok(package)
+        } else {
+            let registry = Artifactory::new(dependency.manifest.registry.clone(), credentials)
+                .wrap_err(DownloadError {
+                    name: dependency.package.clone(),
+                    version: dependency.manifest.version.clone(),
+                })?;
+
+            registry
+                .download(dependency.clone())
+                .await
+                .wrap_err(DownloadError {
+                    name: dependency.package,
+                    version: dependency.manifest.version,
+                })
+        }
+    }
+
+    /// Locates and returns a reference to a resolved dependency package by its name
+    pub fn get(&self, name: &PackageName) -> Option<&ResolvedDependency> {
+        self.entries.get(name)
+    }
+}
+
+impl IntoIterator for DependencyGraph {
+    type Item = ResolvedDependency;
+    type IntoIter = std::collections::hash_map::IntoValues<PackageName, ResolvedDependency>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.entries.into_values()
+    }
+}


### PR DESCRIPTION
This PR refactors the module `package` in the buffrs CLI. Since I am looking to integrate the `validation` crate with `buffrs`, I saw some low-hanging fruits for code improvement. On a high level, the improvements introduced by this PR address the following:

- *async correctness*: not using blocking code in the path of async code. This is quite easy to get wrong in Rust, as of yet there is not much compiler help to avoid this (to my knowledge). In certain cases, it can be okay to mix the two (using a blocking mutex in a hot loop, writing a CLI that is single-threaded). But to build robust, reusable code we should try to get this right.
- *error handling*: error handling is something that can always use some love. This PR adds some error types in strategic places, mostly to make testing easier.
- *test coverage*: this PR attempts to increase net code coverage to 80%.
- *encapsulation*: trying to not leak implementation details when it is not necessary to leak them. This allows us freedom to change the implementation without breaking too many things.
- *robustness*: trying to avoid hidden assumptions by making them explicit. One example for this is the reliance on the current working directory in some of the code paths. 

I try to keep the changes in here to be mostly non-opinionated, so that they are uncontroversial. 

**Edit: this PR is now ready**. Here is a list of the major changes I have made here:

- [Consolidated the `impl PackageStore` blocks](https://github.com/helsing-ai/buffrs/pull/132/commits/3f387ead357b6a57a9bc7d0e09bc87618498aafd). There were multiple of them, I just squashed them together into a single one.
- [Removes superfluous `TryFrom` implementations](https://github.com/helsing-ai/buffrs/pull/132/commits/3e9a3b94ee736934ac2938352308a1aa9bdab624). `TryFrom` and `FromStr` are handy, but we should only implement the ones we need. For cases where a string slice suffices, `FromStr` is the way to go. For cases where ownership is needed, `TryFrom<String>` is the way to go. Always prefer `TryFrom<&str>` over `TryFrom<&String>`, because the former is more generic (the latter is just one specific container type for a `&str`), but usually neither are useful because what you really want is `FromStr`. Here I just removed some implementations that we are not using and that do not add value.
- [Implements custom error type for `PackageName` parsing](https://github.com/helsing-ai/buffrs/pull/132/commits/4e0e377efdefbf87146a8ce728bb66d48a18834e). Here I implemented a custom error type, `PackageNameError`, using `thiserror`. This error type helps write useful unit tests, `miette` is neat for displaying but not so much for "low-level" errors if that makes sense.
- [Changes `Deref` of `PackageName` to target `str`](https://github.com/helsing-ai/buffrs/pull/132/commits/8bfe6e7fc075e6c67eba6859231103ae9c8e0d4d). In general, similar as with the `TryFrom` implementation, always prefer `&str` over `&String`. The reason is that `&str` is a generic string (can be backed by any container). Here, I just swapped out the `Target` of the `Deref` and made it work.
- [Moves resolving code into `src/resolver.rs`](https://github.com/helsing-ai/buffrs/pull/132/commits/9c4c4c7f482e29cb4b2536e05126194fd1091ccc): in having *one module do one thing*, I felt that resolving was different enough to warrant putting it into it's own module.
- [Derive `Default` for `PackageType`](https://github.com/helsing-ai/buffrs/pull/132/commits/88b3c9e17c3b7433781380ec96ff8593affd4d0b). This type already had a manually-implemented `Default`, but I always prefer `derive` implementations over hand-rolled ones unless absolutely necessary, for maintainability and brevity reasons.
- [Don't use `unwrap_or_default`](https://github.com/helsing-ai/buffrs/pull/132/commits/e54e764410275b1197ba514732dc8c6c30f3935c): Rust has amazing error handling, but there are cases where things actually *should* panic. This is one of those, so I have switched to using `unreachable` rather than silently converting to an empty string. If this ever breaks, we certainly want to know about it!
- [Removes `From<&Package>` implementation](https://github.com/helsing-ai/buffrs/pull/132/commits/39f586bed491ef014a5b11bebd4cab0428cc73d3): this implementation was not used and does not add any value, because the data is available in a public field.
- [Add unit tests for `PackageType`](https://github.com/helsing-ai/buffrs/pull/132/commits/1a56a1f2f17c6cd73b935e65a45becf0dbbd8c48): this cleans up `PackageType` a bit, adding unit tests, making the code a bit clearer.
- [Remove implicit assumptions from `PackageStore`](https://github.com/helsing-ai/buffrs/pull/132/commits/af86bcab5131b8fa93f14640901e75cb5dea4dbf): The `PackageStore` currently heavily relies on the current working directory. I do not like using mutable global state, and also for testability purposes this is not great. So instead I added a field that contains the root path that all relative paths are resolved using.
- [Don't read `Manifest` in `PackageStore::release`](https://github.com/helsing-ai/buffrs/pull/132/commits/2dd5b8b83f74f917783ba0f2d839f2ebf078e723): in the interest of decoupling things, we don't really want the `PackageStore` to have to interact with manifests (such as reading them). Rather, we want to decouple them by having it such that the `Manifest` is a method argument that we simply pass through.
- [Decouples `PackageStore` from compression](https://github.com/helsing-ai/buffrs/pull/132/commits/892256735680da4796e1477cb204880548ac2782): similar as with the `Manifest`, our `PackageStore` should only ever deal with package storage things and not with compression. So I have moved the compression-related code out into `Package` instead, this decouples things.

Before:

<img width="863" alt="test-coverage-before" src="https://github.com/helsing-ai/buffrs/assets/786420/af1313ed-83f5-4a7d-a493-124c61fc0dcd">

After:

<img width="863" alt="test-coverage-after" src="https://github.com/helsing-ai/buffrs/assets/786420/93523b1b-99d1-4d05-81bf-a75d3bc0aed7">

I did not quite get the test coverage up to 80%, but we did hit about 77% (with some cheating because I have moved out the resolver code). 

This PR turned out rather wordy, but I hope it all makes sense! I think in a next iteration I could tackle the testing situation a bit more.