### PR TITLE
Runs CI for all crates in workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: rustup update && rustup component add rustfmt
-      - run: cargo fmt -- --check
+      - run: cargo fmt --check --all
 
   clippy:
     runs-on: ubuntu-latest
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: rustup update && rustup component add clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --all-targets -- -D warnings -D clippy::all
+      - run: cargo clippy --all-targets --workspace -- -D warnings -D clippy::all
 
   test:
     runs-on: ubuntu-latest
@@ -29,7 +29,7 @@ jobs:
           lfs: 'true'
       - run: rustup update
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test
+      - run: cargo test --workspace
         env:
           RUST_BACKTRACE: 1
 
@@ -40,7 +40,7 @@ jobs:
       - run: rustup update
       - uses: Swatinem/rust-cache@v2
       - run: cargo install cargo-deny || true
-      - run: cargo deny check
+      - run: cargo deny --workspace check
 
   typos:
     runs-on: ubuntu-latest

--- a/registry/Cargo.toml
+++ b/registry/Cargo.toml
@@ -2,9 +2,11 @@
 name = "buffrs-registry"
 version = "0.1.0"
 edition = "2021"
+description = "Registry for buffrs, a modern protocol buffer package manager"
+license = "Apache-2.0"
 
 [dependencies]
-buffrs = { path = "../" }
+buffrs = { path = "../", version = "0.6.4" }
 prost = "0.12.1"
 tonic = "0.10.2"
 clap = { version = "4.3", features = ["cargo", "derive", "env"] }
@@ -16,4 +18,4 @@ eyre = "0.6.8"
 url = "2.4.1"
 
 [build-dependencies]
-buffrs = { path = "../" }
+buffrs = { path = "../", version = "0.6.4" }

--- a/registry/src/main.rs
+++ b/registry/src/main.rs
@@ -19,6 +19,6 @@ use clap::Parser;
 async fn main() -> eyre::Result<()> {
     let config = Options::parse();
     tracing_subscriber::fmt::init();
-    let db = connect(&config.database.as_str()).await.unwrap();
+    let _db = connect(config.database.as_str()).await.unwrap();
     Ok(())
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -39,7 +39,7 @@ impl Context {
     pub async fn open<P: Into<PathBuf>>(path: P) -> miette::Result<Arc<Self>> {
         Ok(Arc::new(Self {
             store: PackageStore::open(&path.into()).await?,
-            credentials: Credentials::load().await.map(Arc::new)?,
+            credentials: Credentials::read().await?.map(Arc::new).unwrap_or_default(),
         }))
     }
 

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -14,7 +14,7 @@
 
 use miette::{miette, Context, Diagnostic, IntoDiagnostic};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, env, path::PathBuf};
+use std::{collections::HashMap, env, io::ErrorKind, path::PathBuf};
 use thiserror::Error;
 use tokio::fs;
 
@@ -64,17 +64,22 @@ impl Credentials {
     }
 
     /// Reads the credentials from the file system
-    pub async fn read() -> miette::Result<Self> {
-        let raw: RawCredentialCollection = toml::from_str(
-            &fs::read_to_string(location().into_diagnostic()?)
-                .await
-                .into_diagnostic()
-                .wrap_err(ReadError(CREDENTIALS_FILE))?,
-        )
-        .into_diagnostic()
-        .wrap_err(DeserializationError(ManagedFile::Credentials))?;
+    pub async fn read() -> miette::Result<Option<Self>> {
+        let location = location().into_diagnostic()?;
 
-        Ok(raw.into())
+        // if the file does not exist, we don't need to treat it as an error.
+        match fs::read_to_string(&location).await {
+            Ok(contents) => {
+                let raw: RawCredentialCollection = toml::from_str(&contents)
+                    .into_diagnostic()
+                    .wrap_err(DeserializationError(ManagedFile::Credentials))?;
+                Ok(Some(raw.into()))
+            }
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error)
+                .into_diagnostic()
+                .wrap_err(ReadError(CREDENTIALS_FILE)),
+        }
     }
 
     /// Writes the credentials to the file system
@@ -104,7 +109,7 @@ impl Credentials {
     ///
     /// Note: Initializes the credential file if its not present
     pub async fn load() -> miette::Result<Self> {
-        let Ok(credentials) = Self::read().await else {
+        let Some(credentials) = Self::read().await? else {
             let credentials = Credentials::default();
             credentials.write().await.wrap_err("Writing empty config")?;
             return Ok(credentials);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,8 +56,12 @@ pub async fn build() -> miette::Result<()> {
         context.store().proto_vendor_path().display()
     );
 
+    // install dependencies
     context.install().await?;
+
+    // run code generation
     generator::Generator::Tonic.generate().await?;
+
     Ok(())
 }
 

--- a/src/package.rs
+++ b/src/package.rs
@@ -60,9 +60,7 @@ impl PackageStore {
 
     /// Check if this store exists
     async fn exists(&self) -> miette::Result<bool> {
-        let meta = fs::metadata(&self.proto_vendor_path())
-            .await
-            .into_diagnostic()?;
+        let meta = fs::metadata(&self.proto_path()).await.into_diagnostic()?;
 
         Ok(meta.is_dir())
     }


### PR DESCRIPTION
Currently, only the `buffrs` CLI is the recipient of CI scrutiny. This PR makes it so that all crates are checked.

The way this is done is by adding `--all` or `--workspace` flags to the tools. Examples:

```
cargo test --all
cargo clippy --workspace
cargo fmt --all --check
```

This addresses #139.
One issue that also cropped up and is fixed by this is #141. 