### PR TITLE
Check for existence of PackageStore when creating new

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -134,7 +134,8 @@ pub async fn remove(package: PackageName) -> miette::Result<()> {
     //     tracing::warn!("failed to uninstall package {}", dependency.package);
     // }
 
-    PackageStore::current()?
+    PackageStore::current()
+        .await?
         .uninstall(&dependency.package)
         .await
         .ok(); // temporary due to broken test
@@ -145,7 +146,7 @@ pub async fn remove(package: PackageName) -> miette::Result<()> {
 /// Packages the api and writes it to the filesystem
 pub async fn package(directory: impl AsRef<Path>, dry_run: bool) -> miette::Result<()> {
     let manifest = Manifest::read().await?;
-    let package = PackageStore::current()?.release(manifest).await?;
+    let package = PackageStore::current().await?.release(manifest).await?;
 
     let path = directory.as_ref().join(format!(
         "{}-{}.tgz",
@@ -195,7 +196,7 @@ pub async fn publish(
     let artifactory = Artifactory::new(registry, &credentials)?;
 
     let manifest = Manifest::read().await?;
-    let package = PackageStore::current()?.release(manifest).await?;
+    let package = PackageStore::current().await?.release(manifest).await?;
 
     if dry_run {
         tracing::warn!(":: aborting upload due to dry run");
@@ -230,7 +231,8 @@ pub async fn install(credentials: Credentials) -> miette::Result<()> {
             "unexpected error: missing dependency in dependency graph"
         ))?;
 
-        PackageStore::current()?
+        PackageStore::current()
+            .await?
             .unpack(&resolved.package)
             .await
             .wrap_err(miette!(
@@ -283,7 +285,7 @@ pub async fn install(credentials: Credentials) -> miette::Result<()> {
 
 /// Uninstalls dependencies
 pub async fn uninstall() -> miette::Result<()> {
-    PackageStore::current()?.clear().await
+    PackageStore::current().await?.clear().await
 }
 
 /// Generate bindings for a given language

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -63,7 +63,7 @@ impl Generator {
 
         std::env::set_var("PROTOC", protoc.clone());
 
-        let store = PackageStore::current()?;
+        let store = PackageStore::current().await?;
         let protos = store.collect(&store.proto_path()).await;
         let includes = &[store.proto_path()];
 
@@ -123,7 +123,7 @@ impl Generator {
     /// Execute code generation with pre-configured parameters
     pub async fn generate(&self) -> miette::Result<()> {
         let manifest = Manifest::read().await?;
-        let store = PackageStore::current()?;
+        let store = PackageStore::current().await?;
 
         info!(":: initializing code generator");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ pub async fn build() -> miette::Result<()> {
     use credentials::Credentials;
     use package::PackageStore;
 
-    let store = PackageStore::current()?;
+    let store = PackageStore::current().await?;
     println!(
         "cargo:rerun-if-changed={}",
         store.proto_vendor_path().display()


### PR DESCRIPTION
Check for existence of `PackageStore` when creating new.

Resolves #133.

Currently, this still returns a `miette::Result`, which will be addressed in a further PR. 