### PR TITLE
Implements `buffrs` context.

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::{
+    context::Context,
     credentials::Credentials,
     lock::{LockedPackage, Lockfile},
     manifest::{Dependency, Manifest, PackageManifest, MANIFEST_FILE},
@@ -27,7 +28,7 @@ use crate::generator::{Generator, Language};
 use std::path::PathBuf;
 
 use async_recursion::async_recursion;
-use miette::{bail, ensure, miette, Context, IntoDiagnostic};
+use miette::{bail, ensure, miette, Context as _, IntoDiagnostic};
 use semver::{Version, VersionReq};
 use std::{env, path::Path, sync::Arc};
 use tokio::{
@@ -38,263 +39,274 @@ use tokio::{
 const INITIAL_VERSION: Version = Version::new(0, 1, 0);
 const BUFFRS_TESTSUITE_VAR: &str = "BUFFRS_TESTSUITE";
 
-/// Initializes the project
-pub async fn init(kind: PackageType, name: Option<PackageName>) -> miette::Result<()> {
-    if Manifest::exists().await? {
-        bail!("a manifest file was found, project is already initialized");
-    }
-
-    fn curr_dir_name() -> miette::Result<PackageName> {
-        std::env::current_dir()
-            .into_diagnostic()?
-            .file_name()
-            // because the path originates from the current directory, this condition is never met
-            .ok_or(miette!(
-                "unexpected error: current directory path terminates in .."
-            ))?
-            .to_str()
-            .ok_or_else(|| miette!("current directory path is not valid utf-8"))?
-            .parse()
-    }
-
-    let name = name.map(Result::Ok).unwrap_or_else(curr_dir_name)?;
-
-    let manifest = Manifest {
-        package: PackageManifest {
-            kind,
-            name,
-            version: INITIAL_VERSION,
-            description: None,
-        },
-        dependencies: vec![],
-    };
-
-    manifest.write().await?;
-
-    PackageStore::create(std::env::current_dir().unwrap_or_else(|_| ".".into()))
-        .await
-        .wrap_err(miette!("failed to create buffrs project directories"))?;
-    Ok(())
-}
-
-/// Adds a dependency to this project
-pub async fn add(registry: RegistryUri, dependency: &str) -> miette::Result<()> {
-    let lower_kebab = |c: char| (c.is_lowercase() && c.is_ascii_alphabetic()) || c == '-';
-
-    let (repository, dependency) = dependency
-        .trim()
-        .split_once('/')
-        .ok_or_else(|| miette!("locator {dependency} is missing a repository delimiter"))?;
-
-    ensure!(
-        repository.chars().all(lower_kebab),
-        "repository {repository} is not in kebab case"
-    );
-
-    let repository = repository.into();
-
-    let (package, version) = dependency
-        .split_once('@')
-        .ok_or_else(|| miette!("dependency specification is missing version part: {dependency}"))?;
-
-    let package = package
-        .parse::<PackageName>()
-        .wrap_err(miette!("invalid package name: {package}"))?;
-
-    let version = version
-        .parse::<VersionReq>()
-        .into_diagnostic()
-        .wrap_err(miette!("not a valid version requirement: {version}"))?;
-
-    let mut manifest = Manifest::read().await?;
-
-    manifest
-        .dependencies
-        .push(Dependency::new(registry, repository, package, version));
-
-    manifest
-        .write()
-        .await
-        .wrap_err(miette!("failed to write `{MANIFEST_FILE}`"))
-}
-
-/// Removes a dependency from this project
-pub async fn remove(package: PackageName) -> miette::Result<()> {
-    let mut manifest = Manifest::read().await?;
-
-    let match_idx = manifest
-        .dependencies
-        .iter()
-        .position(|d| d.package == package)
-        .ok_or_else(|| miette!("package {package} not in manifest"))?;
-
-    let dependency = manifest.dependencies.remove(match_idx);
-
-    // if PackageStore::uninstall(&dependency.package).await.is_err() {
-    //     tracing::warn!("failed to uninstall package {}", dependency.package);
-    // }
-
-    PackageStore::current()
-        .await?
-        .uninstall(&dependency.package)
-        .await
-        .ok(); // temporary due to broken test
-
-    manifest.write().await
-}
-
-/// Packages the api and writes it to the filesystem
-pub async fn package(directory: impl AsRef<Path>, dry_run: bool) -> miette::Result<()> {
-    let manifest = Manifest::read().await?;
-    let package = PackageStore::current().await?.release(manifest).await?;
-
-    let path = directory.as_ref().join(format!(
-        "{}-{}.tgz",
-        package.manifest.package.name, package.manifest.package.version
-    ));
-
-    if !dry_run {
-        fs::write(path, package.tgz)
-            .await
-            .into_diagnostic()
-            .wrap_err(miette!(
-                "failed to write package release to the current directory"
-            ))?;
-    }
-
-    Ok(())
-}
-
-/// Publishes the api package to the registry
-pub async fn publish(
-    credentials: Credentials,
-    registry: RegistryUri,
-    repository: String,
-    #[cfg(feature = "git")] allow_dirty: bool,
-    dry_run: bool,
-) -> miette::Result<()> {
-    #[cfg(feature = "git")]
-    if let Ok(repository) = git2::Repository::discover(Path::new(".")) {
-        let statuses = repository
-            .statuses(None)
-            .into_diagnostic()
-            .wrap_err(miette!("failed to determine repository status"))?;
-
-        if !allow_dirty && !statuses.is_empty() {
-            tracing::error!("{} files in the working directory contain changes that were not yet committed into git:\n", statuses.len());
-
-            statuses
-                .iter()
-                .for_each(|s| tracing::error!("{}", s.path().unwrap_or_default()));
-
-            tracing::error!("\nTo proceed with publishing despite the uncommitted changes, pass the `--allow-dirty` flag\n");
-
-            bail!("attempted to publish a dirty repository");
+impl Context {
+    /// Initializes the project
+    pub async fn init(kind: PackageType, name: Option<PackageName>) -> miette::Result<()> {
+        if Manifest::exists().await? {
+            bail!("a manifest file was found, project is already initialized");
         }
+
+        fn curr_dir_name() -> miette::Result<PackageName> {
+            std::env::current_dir()
+                .into_diagnostic()?
+                .file_name()
+                // because the path originates from the current directory, this condition is never met
+                .ok_or(miette!(
+                    "unexpected error: current directory path terminates in .."
+                ))?
+                .to_str()
+                .ok_or_else(|| miette!("current directory path is not valid utf-8"))?
+                .parse()
+        }
+
+        let name = name.map(Result::Ok).unwrap_or_else(curr_dir_name)?;
+
+        let manifest = Manifest {
+            package: PackageManifest {
+                kind,
+                name,
+                version: INITIAL_VERSION,
+                description: None,
+            },
+            dependencies: vec![],
+        };
+
+        manifest.write().await?;
+
+        PackageStore::create(std::env::current_dir().unwrap_or_else(|_| ".".into()))
+            .await
+            .wrap_err(miette!("failed to create buffrs project directories"))?;
+        Ok(())
     }
 
-    let artifactory = Artifactory::new(registry, &credentials)?;
-
-    let manifest = Manifest::read().await?;
-    let package = PackageStore::current().await?.release(manifest).await?;
-
-    if dry_run {
-        tracing::warn!(":: aborting upload due to dry run");
-        return Ok(());
-    }
-
-    artifactory.publish(package, repository).await
-}
-
-/// Installs dependencies
-pub async fn install(credentials: Credentials) -> miette::Result<()> {
-    let credentials = Arc::new(credentials);
-
-    let manifest = Manifest::read().await?;
-
-    let lockfile = Lockfile::read_or_default().await?;
-
-    let dependency_graph = DependencyGraph::from_manifest(&manifest, &lockfile, &credentials)
-        .await
-        .wrap_err(miette!("dependency resolution failed"))?;
-
-    let mut locked = Vec::new();
-
-    #[async_recursion]
-    async fn traverse_and_install(
-        name: &PackageName,
-        graph: &DependencyGraph,
-        locked: &mut Vec<LockedPackage>,
-        prefix: String,
+    /// Adds a dependency to this project
+    pub async fn add(
+        self: Arc<Self>,
+        registry: RegistryUri,
+        dependency: &str,
     ) -> miette::Result<()> {
-        let resolved = graph.get(name).ok_or(miette!(
-            "unexpected error: missing dependency in dependency graph"
-        ))?;
+        let lower_kebab = |c: char| (c.is_lowercase() && c.is_ascii_alphabetic()) || c == '-';
+
+        let (repository, dependency) = dependency
+            .trim()
+            .split_once('/')
+            .ok_or_else(|| miette!("locator {dependency} is missing a repository delimiter"))?;
+
+        ensure!(
+            repository.chars().all(lower_kebab),
+            "repository {repository} is not in kebab case"
+        );
+
+        let repository = repository.into();
+
+        let (package, version) = dependency.split_once('@').ok_or_else(|| {
+            miette!("dependency specification is missing version part: {dependency}")
+        })?;
+
+        let package = package
+            .parse::<PackageName>()
+            .wrap_err(miette!("invalid package name: {package}"))?;
+
+        let version = version
+            .parse::<VersionReq>()
+            .into_diagnostic()
+            .wrap_err(miette!("not a valid version requirement: {version}"))?;
+
+        let mut manifest = Manifest::read().await?;
+
+        manifest
+            .dependencies
+            .push(Dependency::new(registry, repository, package, version));
+
+        manifest
+            .write()
+            .await
+            .wrap_err(miette!("failed to write `{MANIFEST_FILE}`"))
+    }
+
+    /// Removes a dependency from this project
+    pub async fn remove(self: Arc<Self>, package: PackageName) -> miette::Result<()> {
+        let mut manifest = Manifest::read().await?;
+
+        let match_idx = manifest
+            .dependencies
+            .iter()
+            .position(|d| d.package == package)
+            .ok_or_else(|| miette!("package {package} not in manifest"))?;
+
+        let dependency = manifest.dependencies.remove(match_idx);
+
+        // if PackageStore::uninstall(&dependency.package).await.is_err() {
+        //     tracing::warn!("failed to uninstall package {}", dependency.package);
+        // }
 
         PackageStore::current()
             .await?
-            .unpack(&resolved.package)
+            .uninstall(&dependency.package)
             .await
-            .wrap_err(miette!(
-                "failed to unpack package {}",
-                &resolved.package.name()
-            ))?;
+            .ok(); // temporary due to broken test
 
-        tracing::info!(
-            "{} installed {}@{}",
-            if prefix.is_empty() { "::" } else { &prefix },
-            name,
-            resolved.package.version()
-        );
+        manifest.write().await
+    }
 
-        locked.push(resolved.package.lock(
-            resolved.registry.clone(),
-            resolved.repository.clone(),
-            resolved.dependants.len(),
-        )?);
+    /// Packages the api and writes it to the filesystem
+    pub async fn package(
+        self: Arc<Self>,
+        directory: impl AsRef<Path>,
+        dry_run: bool,
+    ) -> miette::Result<()> {
+        let manifest = Manifest::read().await?;
+        let package = PackageStore::current().await?.release(manifest).await?;
 
-        for (index, dependency) in resolved.depends_on.iter().enumerate() {
-            let tree_char = if index + 1 == resolved.depends_on.len() {
-                '┗'
-            } else {
-                '┣'
-            };
+        let path = directory.as_ref().join(format!(
+            "{}-{}.tgz",
+            package.manifest.package.name, package.manifest.package.version
+        ));
 
-            let new_prefix = format!(
-                "{} {tree_char}",
-                if prefix.is_empty() { "  " } else { &prefix }
-            );
-            traverse_and_install(dependency, graph, locked, new_prefix).await?;
+        if !dry_run {
+            fs::write(path, package.tgz)
+                .await
+                .into_diagnostic()
+                .wrap_err(miette!(
+                    "failed to write package release to the current directory"
+                ))?;
         }
 
         Ok(())
     }
 
-    for dependency in manifest.dependencies {
-        traverse_and_install(
-            &dependency.package,
-            &dependency_graph,
-            &mut locked,
-            String::new(),
-        )
-        .await?;
+    /// Publishes the api package to the registry
+    pub async fn publish(
+        self: Arc<Self>,
+        registry: RegistryUri,
+        repository: String,
+        #[cfg(feature = "git")] allow_dirty: bool,
+        dry_run: bool,
+    ) -> miette::Result<()> {
+        #[cfg(feature = "git")]
+        if let Ok(repository) = git2::Repository::discover(Path::new(".")) {
+            let statuses = repository
+                .statuses(None)
+                .into_diagnostic()
+                .wrap_err(miette!("failed to determine repository status"))?;
+
+            if !allow_dirty && !statuses.is_empty() {
+                tracing::error!("{} files in the working directory contain changes that were not yet committed into git:\n", statuses.len());
+
+                statuses
+                    .iter()
+                    .for_each(|s| tracing::error!("{}", s.path().unwrap_or_default()));
+
+                tracing::error!("\nTo proceed with publishing despite the uncommitted changes, pass the `--allow-dirty` flag\n");
+
+                bail!("attempted to publish a dirty repository");
+            }
+        }
+
+        let artifactory = Artifactory::new(registry, self.credentials())?;
+
+        let manifest = Manifest::read().await?;
+        let package = PackageStore::current().await?.release(manifest).await?;
+
+        if dry_run {
+            tracing::warn!(":: aborting upload due to dry run");
+            return Ok(());
+        }
+
+        artifactory.publish(package, repository).await
     }
 
-    Lockfile::from_iter(locked.into_iter()).write().await
-}
+    /// Installs dependencies
+    pub async fn install(self: Arc<Self>) -> miette::Result<()> {
+        let manifest = Manifest::read().await?;
+        let lockfile = Lockfile::read_or_default().await?;
+        let dependency_graph =
+            DependencyGraph::from_manifest(&manifest, &lockfile, self.credentials())
+                .await
+                .wrap_err(miette!("dependency resolution failed"))?;
 
-/// Uninstalls dependencies
-pub async fn uninstall() -> miette::Result<()> {
-    PackageStore::current().await?.clear().await
-}
+        let mut locked = Vec::new();
 
-/// Generate bindings for a given language
-#[cfg(feature = "build")]
-pub async fn generate(language: Language, out_dir: PathBuf) -> miette::Result<()> {
-    Generator::Protoc { language, out_dir }
-        .generate()
-        .await
-        .wrap_err(miette!("failed to generate {language} bindings"))
+        #[async_recursion]
+        async fn traverse_and_install(
+            name: &PackageName,
+            graph: &DependencyGraph,
+            locked: &mut Vec<LockedPackage>,
+            prefix: String,
+        ) -> miette::Result<()> {
+            let resolved = graph.get(name).ok_or(miette!(
+                "unexpected error: missing dependency in dependency graph"
+            ))?;
+
+            PackageStore::current()
+                .await?
+                .unpack(&resolved.package)
+                .await
+                .wrap_err(miette!(
+                    "failed to unpack package {}",
+                    &resolved.package.name()
+                ))?;
+
+            tracing::info!(
+                "{} installed {}@{}",
+                if prefix.is_empty() { "::" } else { &prefix },
+                name,
+                resolved.package.version()
+            );
+
+            locked.push(resolved.package.lock(
+                resolved.registry.clone(),
+                resolved.repository.clone(),
+                resolved.dependants.len(),
+            )?);
+
+            for (index, dependency) in resolved.depends_on.iter().enumerate() {
+                let tree_char = if index + 1 == resolved.depends_on.len() {
+                    '┗'
+                } else {
+                    '┣'
+                };
+
+                let new_prefix = format!(
+                    "{} {tree_char}",
+                    if prefix.is_empty() { "  " } else { &prefix }
+                );
+                traverse_and_install(dependency, graph, locked, new_prefix).await?;
+            }
+
+            Ok(())
+        }
+
+        for dependency in manifest.dependencies {
+            traverse_and_install(
+                &dependency.package,
+                &dependency_graph,
+                &mut locked,
+                String::new(),
+            )
+            .await?;
+        }
+
+        Lockfile::from_iter(locked.into_iter()).write().await
+    }
+
+    /// Uninstalls dependencies
+    pub async fn uninstall(self: Arc<Self>) -> miette::Result<()> {
+        PackageStore::current().await?.clear().await
+    }
+
+    /// Generate bindings for a given language
+    #[cfg(feature = "build")]
+    pub async fn generate(
+        self: Arc<Self>,
+        language: Language,
+        out_dir: PathBuf,
+    ) -> miette::Result<()> {
+        Generator::Protoc { language, out_dir }
+            .generate()
+            .await
+            .wrap_err(miette!("failed to generate {language} bindings"))
+    }
 }
 
 /// Logs you in for a registry

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,51 @@
+use crate::{credentials::Credentials, package::PackageStore};
+use miette::{IntoDiagnostic, Result};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+/// Shared context representing `buffrs` project.
+#[derive(Debug)]
+pub struct Context {
+    /// Package store, contains installed dependencies.
+    store: PackageStore,
+    /// Credentials, used to access registries.
+    credentials: Arc<Credentials>,
+}
+
+impl Context {
+    /// Package store
+    pub fn store(&self) -> &PackageStore {
+        &self.store
+    }
+
+    /// Parsed credentials
+    pub fn credentials(&self) -> &Arc<Credentials> {
+        &self.credentials
+    }
+
+    /// Create new context.
+    ///
+    /// This will create and initialize a new `buffrs` project.
+    pub async fn create<P: Into<PathBuf>>(path: P) -> Result<Arc<Self>> {
+        Ok(Arc::new(Self {
+            store: PackageStore::create(path.into()).await?,
+            credentials: Credentials::load().await.map(Arc::new)?,
+        }))
+    }
+
+    /// Open a context by path.
+    ///
+    /// This will check if the path is a valid `buffrs` project, and return an error if it is not.
+    pub async fn open<P: Into<PathBuf>>(path: P) -> Result<Arc<Self>> {
+        Ok(Arc::new(Self {
+            store: PackageStore::open(&path.into()).await?,
+            credentials: Credentials::load().await.map(Arc::new)?,
+        }))
+    }
+
+    /// Open a context in the current working directory.
+    pub async fn open_current() -> Result<Arc<Self>> {
+        let current = std::env::current_dir().into_diagnostic()?;
+        Self::open(current).await
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,5 +1,5 @@
 use crate::{credentials::Credentials, package::PackageStore};
-use miette::{IntoDiagnostic, Result};
+use miette::IntoDiagnostic;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -26,7 +26,7 @@ impl Context {
     /// Create new context.
     ///
     /// This will create and initialize a new `buffrs` project.
-    pub async fn create<P: Into<PathBuf>>(path: P) -> Result<Arc<Self>> {
+    pub async fn create<P: Into<PathBuf>>(path: P) -> miette::Result<Arc<Self>> {
         Ok(Arc::new(Self {
             store: PackageStore::create(path.into()).await?,
             credentials: Credentials::load().await.map(Arc::new)?,
@@ -36,7 +36,7 @@ impl Context {
     /// Open a context by path.
     ///
     /// This will check if the path is a valid `buffrs` project, and return an error if it is not.
-    pub async fn open<P: Into<PathBuf>>(path: P) -> Result<Arc<Self>> {
+    pub async fn open<P: Into<PathBuf>>(path: P) -> miette::Result<Arc<Self>> {
         Ok(Arc::new(Self {
             store: PackageStore::open(&path.into()).await?,
             credentials: Credentials::load().await.map(Arc::new)?,
@@ -44,7 +44,7 @@ impl Context {
     }
 
     /// Open a context in the current working directory.
-    pub async fn open_current() -> Result<Arc<Self>> {
+    pub async fn open_current() -> miette::Result<Arc<Self>> {
         let current = std::env::current_dir().into_diagnostic()?;
         Self::open(current).await
     }

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -30,6 +30,8 @@ pub const BUFFRS_HOME: &str = ".buffrs";
 pub const CREDENTIALS_FILE: &str = "credentials.toml";
 
 /// Credential store for storing authentication data
+///
+/// This type represents a snapshot of the read credential store.
 #[derive(Debug, Default, Clone)]
 pub struct Credentials {
     /// A mapping from registry URIs to their corresponding tokens
@@ -104,7 +106,7 @@ impl Credentials {
     pub async fn load() -> miette::Result<Self> {
         let Ok(credentials) = Self::read().await else {
             let credentials = Credentials::default();
-            credentials.write().await?;
+            credentials.write().await.wrap_err("Writing empty config")?;
             return Ok(credentials);
         };
 


### PR DESCRIPTION
In a discussion it was agreed that the current code base is in a bit of a prototype mode, and some work can be done to set good patterns. We need a `Context` struct that gets passed around which contains all necessary metadata and abstractions that are used for interacting with the `buffrs` project in order to separate concerns and keep code clean.

Currently there are hidden assumptions all over the place, such as implicit state and I/O operations. Any time you call `fs::canonicalize` or `std::env::current_dir`, or you access *anything* with a path that is not an absolute path, you have an **implicit dependency on the current working directory**. The currrent working directory is **mutable, global state**, which can be evil. Similar with reading stuff like the manifest or credentials: we just want to read that data once, at the very beginning, and not multiple times in several places in the code, otherwise we will have an inconsistent view of the world. Instead, we want code that is more compartmentalized and is more *functional*. 

How can we achieve this? We have to think about our data flow. Instead of having a tangled mess of interdependent functions, where everything accesses the outside world, we want to have a clean and clear data flow path. For example, it might look like this:

```mermaid
flowchart LR
    current_dir
    manifest
    credentials
    arguments
    stdout
    side_effects

    subgraph buffrs
        direction LR;
        context
        options
        command
        result
    end

    options-->command
    context-->command
    command-->result
    command-->side_effects
    arguments-->options
    current_dir-->context
    manifest-->context
    credentials-->context
    result-->stdout
```

The idea here is:

- We only ever read stuff *once*, **at the very beginning**, when we build this context. That means this context should contain all information we need to do our job. Specifically, this means the context includes parsed `Credentials`, it includes the root path of our project (and all paths we build, ever, use this root path as base directory). This context represents a snapshot of the information from when the invocation of the `CLI` is started. While the `CLI` runs, data might change on disk and that is fine.
- We only ever write stuff *once*, in the execution of a command. 

## How does it look like in practise?

There is one, and only one instance of `Context`. It is initialized exactly once in the `main.rs`:

```rust
let context = Context::open_current().await?;
```

All subcommands are implemented as methods on this `Context`. The context is wrapped in an `Arc`, so it may be freely passed around, especially to async code that is spawned. It is read-only, and it may never be modified during the duration of the program. `buffrs` is a CLI, so we are fine to read all data once upfront, do our thing, and then exit. We do not need to sync this `Context` with the outside world.

## What does this PR do?

This PR adds a `Context` struct which contains all of that information `buffrs` project. As such, it contains modules used to interact with all parts of a project, including the package store. It also contains metadata such as the credentials that are needed to interacting with the registry.

This PR refactors the code base to use this `Context`.

This resolves #134.

**Note: this PR is the first one of a few, it probably won't get things perfect. I am trying to break tasks down into small, manageable chunks that we can merge rather quickly instead of having large PRs that take a while to review.**