### PR TITLE
Use `Context` in more places

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub async fn build() -> miette::Result<()> {
     context.install().await?;
 
     // run code generation
-    generator::Generator::Tonic.generate().await?;
+    generator::Generator::Tonic.generate(&context).await?;
 
     Ok(())
 }


### PR DESCRIPTION
This commit:

- Removes the remaining uses of `PackageStore::current()`
- Passes the `Context` through to the generator module