### PR TITLE
Sets shared package metadata in workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "buffrs-registry"
-version = "0.1.0"
+version = "0.6.4"
 dependencies = [
  "buffrs",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "buffrs"
-version = "0.6.4"
-edition = "2021"
 description = "Modern protobuf package management"
 authors = ["Mara Schulke <mara.schulke@helsing.ai>"]
-repository = "https://github.com/helsing-ai/buffrs"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
 documentation = "https://docs.rs/buffrs"
 keywords = ["protobuf", "protocol", "buffers", "package", "distribution"]
 categories = ["command-line-utilities"]
 readme = "README.md"
-license = "Apache-2.0"
 
 [[bin]]
 name = "buffrs"
@@ -69,3 +69,14 @@ hex = "0.4.3"
 
 [workspace]
 members = [".", "registry"]
+resolver = "2"
+
+[workspace.package]
+version = "0.6.4"
+license = "Apache-2.0"
+authors = ["Mara Schulke <mara.schulke@helsing.ai>"]
+edition = "2021"
+repository = "https://github.com/helsing-ai/buffrs"
+
+[workspace.dependencies]
+buffrs = { path = ".", version = "0.6.4" }

--- a/registry/Cargo.toml
+++ b/registry/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "buffrs-registry"
-version = "0.1.0"
-edition = "2021"
 description = "Registry for buffrs, a modern protocol buffer package manager"
-license = "Apache-2.0"
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-buffrs = { path = "../", version = "0.6.4" }
+buffrs = { workspace = true }
 prost = "0.12.1"
 tonic = "0.10.2"
 clap = { version = "4.3", features = ["cargo", "derive", "env"] }
@@ -18,4 +19,4 @@ eyre = "0.6.8"
 url = "2.4.1"
 
 [build-dependencies]
-buffrs = { path = "../", version = "0.6.4" }
+buffrs = { workspace = true }


### PR DESCRIPTION
## Challenge

One of the challenges we have here is that we want to be good at structuring things. In the Rust world, one *crate* is one compilation unit, unlike languages such as C or C++ where a *single file* is one compilation unit. 

In general, it is recommended to split projects into small, granular crates if this is possible. It not only serves for better composition (building useful abstractions, not ending up with giant monolithic code bases) but also helps achieve fast builds, especially fast incremental builds.

Currently, it looks like there will be three crates in this repository:

- `buffrs` (both the library and the CLI)
- `buffrs-registry` (the registry, in the `registry/` folder)
- `buffrs-validation` (the code that validates protocol buffer changes, in the `validation/` folder)

In a perfect world, we would properly version these independently. Realistically, as it is all unstable currently we just want to make our lives as simple as possible. 

## Solution

The simplest possible path right now is to just have all crates be at the *same version* and always release them together. Once stability is achieved, this can and should be revisited.

Rust has a special feature to make that easy. We already use the `workspace` feature, which means that our crates share a single `target/` folder and thus benefit from the shared build cache. 

We can use [the `workspace.package` feature](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table) to define common metadata for all crates in this workspace. This allows us to set a single version which is applied to all of them.

## Outlook

This PR is just a suggestion, we do not have to do it this way. It is one of many ways to achieve the end goal. It might be the simplest thing to do at the moment, because it means we can use existing processes.

Feel free to close this PR if you think there is a better way to do this.