### PR TITLE
Fail CI if unit test coverage is lower than threshold.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: ["main"]
   pull_request:
 
+env:
+  MINIMUM_LINE_COVERAGE_PERCENT: 45
+
 jobs:
   fmt:
     runs-on: ubuntu-latest
@@ -41,6 +44,18 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo install cargo-deny || true
       - run: cargo deny --workspace check
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          lfs: 'true'
+      - run: rustup update
+      - run: rustup component add llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo install cargo-llvm-cov || true
+      - run: cargo llvm-cov --workspace --fail-under-lines "$MINIMUM_LINE_COVERAGE_PERCENT"
 
   typos:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Having a good test coverage is a vital part of the strategy to ensure that `buffrs` is and remains stable, and it is an important constaint that ensures that the code written for it is high-quality. This is something that was discussed today with @mara-schulke.

We can define *good test coverage* by something close to 80% or 90%.  The current test coverage is lower than that, it is currently at 45%, depending on how you measure.

This PR is the first one in (hopefully) a series of measures, what this does is enforce that the test coverage does not regress. It works by hardcoding a minimum test coverage percentage (in `.github/workflows/ci.yml` in the `MINIMUM_LINE_COVERAGE_PERCENT` variable).

The idea here is that we can adjust this minimum measure as the project develops, and hopefully increase it to a target value of 80 or 90. At that point, it should never be decreased; forcing all code that is merged to uphold this high standard.