### PR TITLE
Remove ring dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,12 +225,12 @@ dependencies = [
  "protobuf-parse",
  "protoc-bin-vendored",
  "reqwest",
- "ring 0.16.20",
  "semver",
  "serde",
  "serde_json",
  "serde_test",
  "serde_typename",
+ "sha2",
  "similar-asserts",
  "tar",
  "thiserror",
@@ -337,12 +346,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -378,6 +406,16 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "doc-comment"
@@ -523,6 +561,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1456,21 +1504,6 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
@@ -1478,8 +1511,8 @@ dependencies = [
  "cc",
  "getrandom",
  "libc",
- "spin 0.9.8",
- "untrusted 0.9.0",
+ "spin",
+ "untrusted",
  "windows-sys 0.48.0",
 ]
 
@@ -1509,7 +1542,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446e14c5cda4f3f30fe71863c34ec70f5ac79d6087097ad0bb433e1be5edf04c"
 dependencies = [
  "log",
- "ring 0.17.5",
+ "ring",
  "rustls-webpki",
  "sct",
 ]
@@ -1541,8 +1574,8 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.5",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -1575,8 +1608,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.5",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -1682,6 +1715,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1759,12 +1803,6 @@ dependencies = [
  "libc",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -2140,6 +2178,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2177,12 +2221,6 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -2228,6 +2266,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ protobuf = { version = "3.3.0", optional = true }
 protobuf-parse = { version = "3.3.0", optional = true }
 protoc-bin-vendored = { version = "3.0.0", optional = true }
 reqwest = { version = "0.11", features = ["rustls-tls-native-roots"], default-features = false }
-ring = "0.16"
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_typename = "0.1"
@@ -56,6 +55,7 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 url = { version = "2.4", features = ["serde"] }
 walkdir = "2"
+sha2 = "0.10.8"
 
 [dev-dependencies]
 assert_cmd = "2.0"
@@ -65,7 +65,6 @@ hex = "0.4.3"
 paste = "1.0.14"
 predicates = "3.0"
 pretty_assertions = "1.4"
-ring = "0.16.20"
 serde_json = { version = "1.0.107" }
 serde_test = "1.0.176"
 similar-asserts = "1.5.0"

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -6,7 +6,7 @@ use std::{
 use assert_fs::TempDir;
 use fs_extra::dir::{get_dir_content, CopyOptions};
 use pretty_assertions::{assert_eq, assert_str_eq};
-use ring::digest;
+use sha2::Digest;
 
 mod cmd;
 
@@ -150,10 +150,11 @@ impl VirtualFileSystem {
                     }
                     FileType::Binary => {
                         let hash_file = |path| {
-                            hex::encode(digest::digest(
-                                &digest::SHA256,
-                                fs::read(path).expect("file cannot be read").as_slice(),
-                            ))
+                            let contents = fs::read(path).expect("file cannot be read");
+                            let digest = sha2::Sha256::new()
+                                .chain_update(contents.as_slice())
+                                .finalize();
+                            hex::encode(digest)
                         };
 
                         let expected_hash = hash_file(expected);


### PR DESCRIPTION
This PR removes the `ring` crate, and replaces it with the `sha2` crate from the awesome [RustCrypto](https://github.com/RustCrypto/hashes) ecosystem.

Pros:
- The `ring` crate is quite heavyweight, it is basically a replacement for the likes of OpenSSL and BoringSSL. If we only need to hash data with a specific algorithm (this is what we use it for), then it should make a lot more sense to import a crate that *only* does that algorithm, rather than importing the swiss army knife but only using the toothpick.
- The ring crate uses C (ported from BoringSSL) to implement a lot of things. Not really terrible, it is well-tested. I have run into an issue before where [it would not build on RISC-V](https://github.com/briansmith/ring/pull/1436).
- I love using things that are written in pure Rust, which `sha2` is.

Cons:
- We have a dependency on `rustls`, which uses the `ring` crate anyways. 
- Normally, throwing out `ring` should mean a reduction in binary size, but due to our dependency on `rustls` this is not the case. I have tested it using `cargo bloat` and there is no meaningful difference.

Feel free to close this PR if we don't agree that it makes sense!

Cheers!