### PR TITLE
Improve error message for unpinned versions of dependencies

### DIFF
--- a/docs/src/commands/buffrs-add.md
+++ b/docs/src/commands/buffrs-add.md
@@ -27,6 +27,10 @@ Specification](../reference/pkgid-spec.md). The version must adhere to the
 [Semantic Version convention](https://semver.org/) (e.g. `1.2.3`) -- see [SemVer
 compatibility](../reference/semver.md) for more information.
 
+Currently there is no support for resolving version operators but the specific
+version has to be provided. This means `^1.0.0`, `<2.3.0`, `~2.0.0`, etc. can't
+be installed, but `=1.2.3` has to be provided.
+
 #### Lockfile interaction
 
 Currently adding a new dependency won't automatically update the lockfile

--- a/docs/src/getting-started/first-steps.md
+++ b/docs/src/getting-started/first-steps.md
@@ -5,7 +5,7 @@ interface. Let us take a look at its ability to declare protocol buffer
 dependencies and to publish new packages to
 the registry.
 
-To initialize a new project with Buffrs, use `buffrs init`:
+To initialize a new project with Buffrs, use [`buffrs init`](../commands/buffrs-init.md):
 
 ```bash
 $ mkdir web-server && cd web-server
@@ -46,7 +46,7 @@ your protocol buffers as a package.
 Let us define a dependency of the webserver on a hypothetical library
 called `user` in the `datatypes` repository.
 
-This is done by invoking `buffrs add`:
+This is done by invoking [`buffrs add`](../commands/buffrs-add.md):
 
 ```bash
 $ buffrs add --registry https://your.registry.com datatypes/user@=0.1.0


### PR DESCRIPTION
Currently there is no support for version ranges like ^1.0.0 or <=2.3.4. Improve the error message during installation if the user tries to install such a version.