### PR TITLE
Require at least tokio 1.26.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ serde = { version = "1", features = ["derive"] }
 serde_typename = "0.1"
 tar = "0.4"
 thiserror = "1.0.49"
-tokio = { version = "1", features = ["fs", "rt", "macros", "process", "io-std", "tracing"] }
+tokio = { version = "^1.26", features = ["fs", "rt", "macros", "process", "io-std", "tracing"] }
 toml = "0.8.0"
 tonic-build = { version = "0.10.0", optional = true }
 tracing = "0.1"


### PR DESCRIPTION
buffrs uses [tokio::fs::try_exists](https://docs.rs/tokio/1.26.0/tokio/fs/fn.try_exists.html) which was only added in tokio v1.26.0.

Not pinning it might result in compilation errors if buffrs is used programmatically in projects with a lower tokio version dependency.