### PR TITLE
Make static lifetime of constants explicit

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -53,7 +53,7 @@ pub enum Generator {
 
 impl Generator {
     /// Tonic include file name
-    pub const TONIC_INCLUDE_FILE: &str = "buffrs.rs";
+    pub const TONIC_INCLUDE_FILE: &'static str = "buffrs.rs";
 
     /// Run the generator for a dependency and output files at the provided path
     pub async fn run(&self) -> miette::Result<()> {

--- a/src/package/store.rs
+++ b/src/package/store.rs
@@ -35,9 +35,9 @@ pub struct PackageStore {
 
 impl PackageStore {
     /// Path to the proto directory
-    pub const PROTO_PATH: &str = "proto";
+    pub const PROTO_PATH: &'static str = "proto";
     /// Path to the dependency store
-    pub const PROTO_VENDOR_PATH: &str = "proto/vendor";
+    pub const PROTO_VENDOR_PATH: &'static str = "proto/vendor";
 
     fn new(root: PathBuf) -> Self {
         Self { root }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -31,8 +31,8 @@ pub struct VirtualFileSystem {
 }
 
 impl VirtualFileSystem {
-    const VIRTUAL_HOME: &str = "$HOME";
-    const ROOT_NAME: &str = "root";
+    const VIRTUAL_HOME: &'static str = "$HOME";
+    const ROOT_NAME: &'static str = "root";
 
     /// Init an empty virtual file system
     pub fn empty() -> Self {


### PR DESCRIPTION
The most recent version of clippy complains about missing explicit lifetime annotators for constants.