### PR TITLE
chore: update aws-sdk to v1

### DIFF
--- a/registry/Cargo.toml
+++ b/registry/Cargo.toml
@@ -8,8 +8,8 @@ default-run = "buffrs-registry"
 
 [dependencies]
 async-trait = "0.1.74"
-aws-config = { version = "0.56.1", optional = true }
-aws-sdk-s3 = { version = "0.34.0", optional = true }
+aws-config = { version = "1.0.1", optional = true }
+aws-sdk-s3 = { version = "1.4.0", optional = true }
 axum_tonic = "0.1.0"
 buffrs = { path = "../", version = "0.7.1" }
 bytes = "1.5.0"
@@ -36,7 +36,7 @@ default = ["storage-s3"]
 storage-s3 = ["dep:aws-config", "dep:aws-sdk-s3"]
 
 [dev-dependencies]
-aws-credential-types = { version = "0.56.1", features = ["hardcoded-credentials"] }
+aws-credential-types = { version = "1.0.1", features = ["hardcoded-credentials"] }
 proptest = "1.3.1"
 rand = "0.8.5"
 tempfile = "3.8.1"

--- a/src/command.rs
+++ b/src/command.rs
@@ -281,7 +281,7 @@ pub async fn install() -> miette::Result<()> {
             resolved.registry.clone(),
             resolved.repository.clone(),
             resolved.dependants.len(),
-        )?);
+        ));
 
         for (index, dependency) in resolved.depends_on.iter().enumerate() {
             let tree_char = if index + 1 == resolved.depends_on.len() {

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -65,8 +65,8 @@ impl LockedPackage {
         registry: RegistryUri,
         repository: String,
         dependants: usize,
-    ) -> miette::Result<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             name: package.name().to_owned(),
             registry,
             repository,
@@ -79,7 +79,7 @@ impl LockedPackage {
                 .map(|d| d.package.clone())
                 .collect(),
             dependants,
-        })
+        }
     }
 
     /// Validates if another LockedPackage matches this one

--- a/src/package/compressed.rs
+++ b/src/package/compressed.rs
@@ -198,14 +198,12 @@ impl Package {
     }
 
     /// Lock this package
-    ///
-    /// Note that despite returning a Result this function never fails
     pub fn lock(
         &self,
         registry: RegistryUri,
         repository: String,
         dependants: usize,
-    ) -> miette::Result<LockedPackage> {
+    ) -> LockedPackage {
         LockedPackage::lock(self, registry, repository, dependants)
     }
 }


### PR DESCRIPTION
With AWS SDK hitting [v1](https://aws.amazon.com/blogs/developer/announcing-general-availability-of-the-aws-sdk-for-rust/) it's worth updating to semver-respecting version.