### PR TITLE
fix: buffrs should not use protoc-bin-vendored

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: arduino/setup-protoc@v2
       - run: rustup update && rustup component add clippy
       - uses: Swatinem/rust-cache@v2
       - run: cd registry && cargo clippy --all-targets --workspace -- -D warnings -D clippy::all
@@ -30,6 +31,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           lfs: "true"
+      - uses: arduino/setup-protoc@v2
       - uses: isbang/compose-action@v1.5.1
         with:
           compose-file: "./registry/docker-compose.yml"
@@ -54,6 +56,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           lfs: 'true'
+      - uses: arduino/setup-protoc@v2
       - uses: isbang/compose-action@v1.5.1
         with:
           compose-file: "./registry/docker-compose.yml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,7 +223,7 @@ dependencies = [
  "pretty_assertions",
  "protobuf",
  "protobuf-parse",
- "protoc-bin-vendored",
+ "protoc",
  "reqwest",
  "semver",
  "serde",
@@ -1351,54 +1351,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "protoc-bin-vendored"
-version = "3.0.0"
+name = "protoc"
+version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005ca8623e5633e298ad1f917d8be0a44bcf406bf3cde3b80e63003e49a3f27d"
+checksum = "a0218039c514f9e14a5060742ecd50427f8ac4f85a6dc58f2ddb806e318c55ee"
 dependencies = [
- "protoc-bin-vendored-linux-aarch_64",
- "protoc-bin-vendored-linux-ppcle_64",
- "protoc-bin-vendored-linux-x86_32",
- "protoc-bin-vendored-linux-x86_64",
- "protoc-bin-vendored-macos-x86_64",
- "protoc-bin-vendored-win32",
+ "log",
+ "which",
 ]
-
-[[package]]
-name = "protoc-bin-vendored-linux-aarch_64"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb9fc9cce84c8694b6ea01cc6296617b288b703719b725b8c9c65f7c5874435"
-
-[[package]]
-name = "protoc-bin-vendored-linux-ppcle_64"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d2a07dcf7173a04d49974930ccbfb7fd4d74df30ecfc8762cf2f895a094516"
-
-[[package]]
-name = "protoc-bin-vendored-linux-x86_32"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54fef0b04fcacba64d1d80eed74a20356d96847da8497a59b0a0a436c9165b0"
-
-[[package]]
-name = "protoc-bin-vendored-linux-x86_64"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8782f2ce7d43a9a5c74ea4936f001e9e8442205c244f7a3d4286bd4c37bc924"
-
-[[package]]
-name = "protoc-bin-vendored-macos-x86_64"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5de656c7ee83f08e0ae5b81792ccfdc1d04e7876b1d9a38e6876a9e09e02537"
-
-[[package]]
-name = "protoc-bin-vendored-win32"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9653c3ed92974e34c5a6e0a510864dab979760481714c172e0a34e437cb98804"
 
 [[package]]
 name = "quote"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ test = true
 
 [features]
 default = ["build", "git", "validation"]
-build = ["dep:tonic-build", "dep:protoc-bin-vendored"]
+build = ["dep:tonic-build", "dep:protoc"]
 validation = ["dep:anyhow", "dep:protobuf", "dep:protobuf-parse", "dep:diff-struct"]
 git = ["dep:git2"]
 
@@ -41,7 +41,7 @@ human-panic = "1"
 miette = { version = "5.10.0", features = ["fancy"] }
 protobuf = { version = "3.3.0", optional = true }
 protobuf-parse = { version = "3.3.0", optional = true }
-protoc-bin-vendored = { version = "3.0.0", optional = true }
+protoc = { version = "2.28.0", optional = true }
 reqwest = { version = "0.11", features = ["rustls-tls-native-roots"], default-features = false }
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Instead, we should use [protoc](https://docs.rs/protoc/latest/protoc/) crate for working with user provided binary.

BREAKING CHANGE: we will break workflows for people who do not have `protoc` installed locally

Closes https://github.com/helsing-ai/buffrs/issues/174.