### PR TITLE
Unignore tests

### DIFF
--- a/src/registry/local.rs
+++ b/src/registry/local.rs
@@ -105,7 +105,6 @@ mod tests {
     use tokio::fs;
 
     #[tokio::test]
-    #[ignore = "gzip header is invalid"]
     async fn can_publish_and_fetch() {
         let dir = env::temp_dir();
         let registry = LocalRegistry::new(dir.clone());

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -54,7 +54,7 @@ impl DependencyGraph {
         lockfile: &Lockfile,
         credentials: &Arc<Credentials>,
     ) -> miette::Result<Self> {
-        let name = manifest.package.name.clone();
+        let name = &manifest.package.name;
 
         let mut entries = HashMap::new();
 

--- a/tests/cmd/package/mod.rs
+++ b/tests/cmd/package/mod.rs
@@ -1,7 +1,6 @@
 use crate::VirtualFileSystem;
 
 #[test]
-#[ignore = "sha mismatch, tar files should be compared by contents!"]
 fn fixture() {
     let vfs = VirtualFileSystem::copy(crate::parent_directory!().join("in"));
 

--- a/tests/cmd/package/out/lib-0.0.1.tgz
+++ b/tests/cmd/package/out/lib-0.0.1.tgz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9b649f1f60b4c5d42fe0d5ac69584568815b172a87b5ee1c22c7bff78854834a
-size 251
+oid sha256:3cd4b2d88f920e9b27217d580e097abde1c15377e8dcc290f96a9f3391ab14ba
+size 662

--- a/tests/cmd/package/out/proto/vendor/lib/foo/bar.proto
+++ b/tests/cmd/package/out/proto/vendor/lib/foo/bar.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package foo;
+
+message Bar {
+    string foo = 1;
+}

--- a/tests/cmd/package/out/proto/vendor/lib/hello.proto
+++ b/tests/cmd/package/out/proto/vendor/lib/hello.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+message Hello {
+    string name = 1;
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -26,12 +26,6 @@ macro_rules! cli {
     };
 }
 
-fn read_package(path: &PathBuf) -> Package {
-    Bytes::from(fs::read(path).expect("file cannot be read"))
-        .try_into()
-        .expect("package could not be parsed")
-}
-
 /// A virtual file system which enables temporary fs operations
 pub struct VirtualFileSystem {
     tmp_dir: TempDir,
@@ -157,6 +151,11 @@ impl VirtualFileSystem {
                         );
                     }
                     FileType::Package => {
+                        fn read_package(path: &PathBuf) -> Package {
+                            Bytes::from(fs::read(path).expect("file cannot be read"))
+                                .try_into()
+                                .expect("package could not be parsed")
+                        }
                         let actual = read_package(&actual);
                         let expected = read_package(&expected);
                         let actual_vfs = VirtualFileSystem::empty();

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -9,7 +9,6 @@ use assert_fs::TempDir;
 use bytes::Bytes;
 use fs_extra::dir::{get_dir_content, CopyOptions};
 use pretty_assertions::{assert_eq, assert_str_eq};
-use sha2::Digest;
 
 mod cmd;
 
@@ -157,23 +156,6 @@ impl VirtualFileSystem {
                             fs::read_to_string(&actual).expect("file cannot be read")
                         );
                     }
-                    FileType::Binary => {
-                        let hash_file = |path| {
-                            let contents = fs::read(path).expect("file cannot be read");
-                            let digest = sha2::Sha256::new()
-                                .chain_update(contents.as_slice())
-                                .finalize();
-                            hex::encode(digest)
-                        };
-
-                        let expected_hash = hash_file(expected);
-                        let actual_hash = hash_file(actual);
-
-                        assert_eq!(
-                            expected_hash, actual_hash,
-                            "expected hash {expected_hash} actual hash {actual_hash}"
-                        );
-                    }
                     FileType::Package => {
                         let actual = read_package(&actual);
                         let expected = read_package(&expected);
@@ -212,8 +194,6 @@ macro_rules! parent_directory {
 }
 
 enum FileType {
-    #[allow(dead_code)]
-    Binary,
     Package,
     Text,
 }


### PR DESCRIPTION
Two tests are enabled by this PR:

 - `can_publish_and_fetch`, which actually passes as-is
 - `cmd::package::fixture`, which needed archive introspection instead of comparing hashes

I also include a very minor commit, which just removes one unneeded clone.