### PR TITLE
Add fetch version basis

### DIFF
--- a/registry/proto/registry.proto
+++ b/registry/proto/registry.proto
@@ -35,7 +35,13 @@ message DownloadResponse {
 }
 
 message VersionsRequest {
+    // package name
     string name = 1;
+    /* `requirement` expects to follow the [`semver::VersionReq`] format
+     * https://docs.rs/semver/latest/semver/struct.VersionReq.html
+     * Examples: 
+     * >=1.0.0
+     * >=1.2.3, <1.8 */
     string requirement = 2;
 }
 

--- a/registry/src/metadata.rs
+++ b/registry/src/metadata.rs
@@ -20,6 +20,8 @@
 pub mod memory;
 
 use buffrs::manifest::PackageManifest;
+use buffrs::package::PackageName;
+use semver::VersionReq;
 
 use std::fmt;
 use std::sync::Arc;
@@ -39,7 +41,7 @@ pub type SharedError = Arc<dyn std::error::Error + Send + Sync>;
 pub enum MetadataStorageError {
     /// Package missing
     #[error("package missing")]
-    PackageMissing(String, String),
+    PackageMissing(String, Option<String>),
 
     /// Duplicate package
     /// Used on put_version mostly
@@ -67,6 +69,13 @@ pub trait MetadataStorage: Send + Sync + fmt::Debug {
         &self,
         package: PackageVersion,
     ) -> Result<PackageManifest, MetadataStorageError>;
+
+    /// Fetches a package with a given version and all packages above that version
+    async fn get_versions(
+        &self,
+        package_name: PackageName,
+        version: Option<VersionReq>,
+    ) -> Result<Vec<PackageManifest>, MetadataStorageError>;
 
     /// Puts the given package in the storage
     async fn put_version(&self, package: PackageManifest) -> Result<(), MetadataStorageError>;


### PR DESCRIPTION
This PR intends to continue my work from: https://github.com/helsing-ai/buffrs/pull/210 and implement "fetch version" gRPC APIs
Added a basic test with it

Testing scenario:
```md
- Publishing Package 1.0.0
- Publishing Package 1.1.1
- Fetching Version with requirement `>=1.1`
- Ensure fetched versions only contains `1.1.1`
```