### PR TITLE
ci: fix ci after removing registry specific workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,18 +2,9 @@ name: Buffrs CLI
 
 on:
   push:
-    branches: ["main"]
-    paths:
-      - 'Cargo.lock'
-      - 'Cargo.toml'
-      - 'deny.toml'
-      - 'src/**'
+    branches:
+      - main
   pull_request:
-    paths:
-      - 'Cargo.lock'
-      - 'Cargo.toml'
-      - 'deny.toml'
-      - 'src/**'
 
 env:
   MINIMUM_LINE_COVERAGE_PERCENT: 35


### PR DESCRIPTION
https://github.com/helsing-ai/buffrs/commit/a9fc63b9d928199cf11e8ce0be40dcf525c3beb5 removed registry-only workflow, but it didn't modify the unified workflow to trigger on changes to registry folder.

This MR simplifies CI to run on *any* changes to the project