### PR TITLE
Eg/add sheilds to indicate build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 [![Helsing](https://img.shields.io/badge/helsing-open%20source-black.svg)](https://helsing.ai)
 [![Buffrs Crate](https://img.shields.io/crates/v/buffrs.svg)](https://crates.io/crates/buffrs)
 [![Buffrs Book](https://img.shields.io/badge/book-latest-blueviolet.svg)](https://helsing-ai.github.io/buffrs)
-
 [![Buffrs Docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://docs.rs/buffrs)
+
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/helsing-ai/buffrs/nix_ci_mac.yml?logo=nixos&label=mac%20build)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/helsing-ai/buffrs/nix_ci_ubuntu.yml?logo=nixos&label=ubuntu%20build)
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@
 [![Buffrs Crate](https://img.shields.io/crates/v/buffrs.svg)](https://crates.io/crates/buffrs)
 [![Buffrs Book](https://img.shields.io/badge/book-latest-blueviolet.svg)](https://helsing-ai.github.io/buffrs)
 [![Buffrs Docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://docs.rs/buffrs)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/helsing-ai/buffrs/nix_ci_mac.yml?logo=nixos&label=mac%20build)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/helsing-ai/buffrs/nix_ci_ubuntu.yml?logo=nixos&label=ubuntu%20build)
+
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![Helsing](https://img.shields.io/badge/helsing-open%20source-black.svg)](https://helsing.ai)
 [![Buffrs Crate](https://img.shields.io/crates/v/buffrs.svg)](https://crates.io/crates/buffrs)
 [![Buffrs Book](https://img.shields.io/badge/book-latest-blueviolet.svg)](https://helsing-ai.github.io/buffrs)
+
 [![Buffrs Docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://docs.rs/buffrs)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/helsing-ai/buffrs/nix_ci_mac.yml?logo=nixos&label=mac%20build)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/helsing-ai/buffrs/nix_ci_ubuntu.yml?logo=nixos&label=ubuntu%20build)

--- a/deny.toml
+++ b/deny.toml
@@ -11,3 +11,6 @@ license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 [bans]
 multiple-versions = "warn"
 wildcards = "deny"
+
+[advisories]
+ignore = ["RUSTSEC-2024-0013"]


### PR DESCRIPTION
Added shields to indicate the status of nix CI.

Mac builds only run after a merge. This lets us see at a glance whether something has gone wrong.