### PR TITLE
Ignoring statuses of synched files under vendor when publishing

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -204,8 +204,16 @@ pub async fn publish(
 ) -> miette::Result<()> {
     #[cfg(feature = "git")]
     if let Ok(repository) = git2::Repository::discover(Path::new(".")) {
+        
+        let mut status_options = git2::StatusOptions::default();
+        let status_options = Some(status_options
+            .include_untracked(true)
+            .pathspec("Proto.toml")
+            .pathspec("proto/*.proto")
+        );
+
         let statuses = repository
-            .statuses(None)
+            .statuses(status_options)
             .into_diagnostic()
             .wrap_err(miette!("failed to determine repository status"))?;
 


### PR DESCRIPTION
Regarding issue https://github.com/helsing-ai/buffrs/issues/200
This change adds some options to the check of the repository when publishing your Buffrs project.

When publishing, the statuses of the synched *.proto files under vendor are not included, avoiding the project being dirty as described in the issue