### PR TITLE
devshell: add protobuf, requirement to make all tests pass

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,7 @@
           pkgs.callPackage ./nix/cache.nix { buffrs = buffrs.package; };
 
         devShells.default = pkgs.mkShell ({
-          inherit nativeBuildInputs;
+          nativeBuildInputs = nativeBuildInputs ++ [ pkgs.protobuf ];
           buildInputs = devTools ++ dependencies;
         } // buildEnvVars);
 


### PR DESCRIPTION
Currently doing `nix develop` then `cargo nextest run` fails because one test needs `protoc` in `PATH`.