### PR TITLE
Refactor the registry system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,6 +868,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_test",
+ "serde_with",
  "sha2",
  "similar-asserts",
  "strum",
@@ -990,7 +991,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -1166,6 +1167,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,6 +1229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -2348,6 +2385,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2387,6 +2430,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -2397,6 +2441,7 @@ checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
+ "serde",
 ]
 
 [[package]]
@@ -3561,6 +3606,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee80b0e361bbf88fd2f6e242ccd19cfda072cb0faa6ae694ecee08199938569a"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.2.6",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6561dc161a9224638a31d876ccdfefbc1df91d3f3a8342eddb35f055d48c7655"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3944,6 +4019,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ reqwest = { version = "0.11", features = ["rustls-tls-native-roots"], default-fe
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_with = "3.7"
 tar = "0.4"
 thiserror = "1.0.49"
 tokio = { version = "^1.26", features = ["fs", "rt", "macros", "process", "io-std", "tracing"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,95 @@
+// Copyright 2023 Helsing GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use miette::{miette, Context, IntoDiagnostic};
+use serde::{Deserialize, Serialize};
+use std::{io::ErrorKind, path::PathBuf};
+use tokio::fs;
+
+use crate::{
+    errors::{DeserializationError, FileExistsError, ReadError, SerializationError, WriteError},
+    registry::RegistryTable,
+    ManagedFile,
+};
+
+/// Filename of the config file
+pub const CONFIG_FILE: &str = "config.toml";
+
+/// Configuration file for the buffrs cli
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct Config {
+    /// A mapping from registry name to their corresponding uri
+    pub registry: Option<RegistryTable>,
+}
+
+impl Config {
+    fn location() -> PathBuf {
+        PathBuf::from("./.buffrs/").join(CONFIG_FILE)
+    }
+
+    /// Checks if the credentials exists
+    pub async fn exists() -> miette::Result<bool> {
+        fs::try_exists(Self::location())
+            .await
+            .into_diagnostic()
+            .wrap_err(FileExistsError(CONFIG_FILE))
+    }
+
+    /// Reads the credentials from the file system
+    pub async fn read() -> miette::Result<Option<Self>> {
+        // if the file does not exist, we don't need to treat it as an error.
+        match fs::read_to_string(Self::location()).await {
+            Ok(contents) => {
+                let raw = toml::from_str(&contents)
+                    .into_diagnostic()
+                    .wrap_err(DeserializationError(ManagedFile::Configuration))?;
+
+                Ok(Some(raw))
+            }
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error)
+                .into_diagnostic()
+                .wrap_err(ReadError(CONFIG_FILE)),
+        }
+    }
+
+    /// Writes the credentials to the file system
+    pub async fn write(&self) -> miette::Result<()> {
+        let location = Self::location();
+
+        if let Some(parent) = location.parent() {
+            // if directory already exists, error is returned but that is fine
+            fs::create_dir(parent).await.ok();
+        }
+
+        fs::write(
+            location,
+            toml::to_string(&self)
+                .into_diagnostic()
+                .wrap_err(SerializationError(ManagedFile::Configuration))?
+                .into_bytes(),
+        )
+        .await
+        .into_diagnostic()
+        .wrap_err(WriteError(CONFIG_FILE))
+    }
+
+    /// Loads the config from the file system, returning an error if it doesnt exist
+    pub async fn load() -> miette::Result<Self> {
+        Self::read()
+            .await
+            .transpose()
+            .ok_or(miette!("missing configuration file"))?
+    }
+}

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -19,7 +19,7 @@ use tokio::fs;
 
 use crate::{
     errors::{DeserializationError, FileExistsError, ReadError, SerializationError, WriteError},
-    registry::RegistryUri,
+    registry::Registry,
     ManagedFile,
 };
 
@@ -31,8 +31,8 @@ pub const CREDENTIALS_FILE: &str = "credentials.toml";
 /// This type represents a snapshot of the read credential store.
 #[derive(Debug, Default, Clone)]
 pub struct Credentials {
-    /// A mapping from registry URIs to their corresponding tokens
-    pub registry_tokens: HashMap<RegistryUri, String>,
+    /// A mapping from registry to their corresponding tokens
+    pub tokens: HashMap<Registry, String>,
 }
 
 impl Credentials {
@@ -108,7 +108,7 @@ struct RawCredentialCollection {
 /// Credentials for a single registry. Serialization type.
 #[derive(Serialize, Deserialize)]
 struct RawRegistryCredentials {
-    uri: RegistryUri,
+    registry: Registry,
     token: String,
 }
 
@@ -117,11 +117,11 @@ impl From<RawCredentialCollection> for Credentials {
         let credentials = value
             .credentials
             .into_iter()
-            .map(|it| (it.uri, it.token))
+            .map(|it| (it.registry, it.token))
             .collect();
 
         Self {
-            registry_tokens: credentials,
+            tokens: credentials,
         }
     }
 }
@@ -129,9 +129,9 @@ impl From<RawCredentialCollection> for Credentials {
 impl From<Credentials> for RawCredentialCollection {
     fn from(value: Credentials) -> Self {
         let credentials = value
-            .registry_tokens
+            .tokens
             .into_iter()
-            .map(|(uri, token)| RawRegistryCredentials { uri, token })
+            .map(|(registry, token)| RawRegistryCredentials { registry, token })
             .collect();
 
         Self { credentials }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@ use thiserror::Error;
 pub mod cache;
 /// CLI command implementations
 pub mod command;
+/// Configuration for the CLI
+pub mod config;
 /// Credential management
 pub mod credentials;
 /// Common error types
@@ -63,6 +65,7 @@ fn home() -> Result<PathBuf, HomeError> {
 
 #[derive(Debug)]
 pub(crate) enum ManagedFile {
+    Configuration,
     Credentials,
     Manifest,
     Lock,
@@ -70,11 +73,13 @@ pub(crate) enum ManagedFile {
 
 impl ManagedFile {
     fn name(&self) -> &str {
+        use config::CONFIG_FILE;
         use credentials::CREDENTIALS_FILE;
         use lock::LOCKFILE;
         use manifest::MANIFEST_FILE;
 
         match self {
+            ManagedFile::Configuration => CONFIG_FILE,
             ManagedFile::Manifest => MANIFEST_FILE,
             ManagedFile::Lock => LOCKFILE,
             ManagedFile::Credentials => CREDENTIALS_FILE,


### PR DESCRIPTION
## Current State

At the moment users specify _registries and repositories_ in every single dependency declaration. This does not only lead to a chunky `Proto.toml` as we repeat common information way more often that we actually need to, it also has a semantic impact:

It allows users to request a dependencies from distributed registries at the same time and it inherently teaches buffrs about the existence of repositories.

E.g.

```toml
[dependencies]
foo = { registry = "https://foo.bar/baz", repository = "bar", version = "=1.0.0" }
```

## Context

In the realm of dynamic version resolution we need to rethink this current state: Established version resolution algorithms like [pubgrub](https://pubgrub-rs-guide.netlify.app) and [resolve](https://crates.io/crates/resolvo) are not aware of this situation. 

E.g. in the current situation a package `a@1.0.1` could be present in the repository `foo` and `a@1.0.2` could be present in the repository `baz`. When using the above mentioned version solvers with a request to install `a>=1.0` this leads to a quite hard decision problem: Do we want to jump repositories when we know that there is a later stable release present in another one? How do we get to know about the other repository? Is this the desired behavior?

Although this setup may seem odd at first glance it is not so far of some real world setups using artifactory where repositories are used to distinguish between stability. E.g. many companies publish prereleases and stable releases into different repositories.

## A possible way forward

Some possible ideas to solve this problem are:

### Using Named Registries

Using named registries we can move towards a registry based approach and drop our in-manifest knowledge about repositories altogether.

Users could name registries in a configuration file and declare a set of artifactory repositories to search through:

`$HOME/.buffrs/config.toml` / `$PWD/.buffrs/config.toml`:
```
[registry]
default = { uri = "http://foo.bar/baz", repositories = ["a", "b", "c"] }
```

When installing buffrs would now search the above repositories (using the artifactory search api) to locate possible releases. This would be quite efficient and elegant as this would result in the manifest looking like this:

```
[dependency]
foo = "=1.0.0"
```

or (`foo = { version = "=1.0.0" }`). Which is not only much more readable but also leaves us the ability to jump around repositories within the same registry to resolve different versions, thus unifying the version set from being sharded across repositories into one big searchable version set for version resolution. All of this is achieved while stripping out the repository concept from the actual buffrs manifests!

One caveat is that we need to still specify the exact repository when publishing, but this can be done via the cli anyway.

### Dropping prereleases

See [pubgrubs take on prereleases](https://pubgrub-rs-guide.netlify.app/limitations/prerelease_versions). They introduce a lot of headache when trying to do version resolution correctly and it may be a good tradeoff to drop their support for now in order to ship proper dependency resolution.

---

I am probably not going to have the time to finish this any time soon, contributions are welcome.