### PR TITLE
docs: fix all broken doc links

### DIFF
--- a/registry/src/context.rs
+++ b/registry/src/context.rs
@@ -53,7 +53,7 @@ impl Context {
         &self.storage
     }
 
-    /// Get reference to the [`MetadataStorage`] instance
+    /// Get reference to the [`PgsqlMetadataStorage`] instance
     pub fn metadata_store(&self) -> &PgsqlMetadataStorage {
         &self.metadata_storage
     }

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -20,7 +20,8 @@
 //! ## Dependencies
 //!
 //! It requires two stateful services: one to store metadata, which is expressed by the
-//! [`Database`](db::Database) trait. Typically, this would be implemented using a Postgres
+//! [`FetchMatching`](metadata::FetchMatching), [`Publish`](metadata::Publish) and
+//! [`TryFetch`](metadata::TryFetch) traits. Typically, this would be implemented using a Postgres
 //! database, but the code is written in a way that other services can be plugged in instead.
 //!
 //! The other dependency it has is on a way to store package sources, which is expressed using the

--- a/registry/src/metadata.rs
+++ b/registry/src/metadata.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! # Metadata Storage trait and implementations.
+//! # Metadata storage traits and implementations.
 //!
-//! [`MetadataStorage`]
+//! [`TryFetch`], [`FetchMatching`] and [`Publish`]
 
 /// memory provider
 pub mod memory;


### PR DESCRIPTION
Small fixes so docs don't give out warnings when built from `main`