### PR TITLE
Add rust tests to nix checks

### DIFF
--- a/nix/buffrs.nix
+++ b/nix/buffrs.nix
@@ -44,7 +44,7 @@ in {
       partitions = 1;
       partitionType = "count";
       # Ignore tutorial and publish tests because they need TLS certificates 
-      # which doens't yet work in our next setup
+      # which doens't yet work in our nix setup
       cargoNextestExtraArgs =
         "--filter-expr 'all() - test(=cmd::tuto::fixture) - test(=cmd::publish::fixture)'";
     });

--- a/nix/buffrs.nix
+++ b/nix/buffrs.nix
@@ -43,10 +43,10 @@ in {
       inherit cargoArtifacts;
       partitions = 1;
       partitionType = "count";
-      # Ignore tutorial and publish tests because they need TLS certificates 
-      # which doesn't yet work in our nix setup
+      # Ignore tutorial test because it requires git and cargo to work
       cargoNextestExtraArgs =
-        "--filter-expr 'all() - test(=cmd::tuto::fixture) - test(=cmd::publish::fixture)'";
+        "--filter-expr 'all() - test(=cmd::tuto::fixture)'";
+      SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
     });
   };
 }

--- a/nix/buffrs.nix
+++ b/nix/buffrs.nix
@@ -44,7 +44,7 @@ in {
       partitions = 1;
       partitionType = "count";
       # Ignore tutorial and publish tests because they need TLS certificates 
-      # which doens't yet work in our nix setup
+      # which doesn't yet work in our nix setup
       cargoNextestExtraArgs =
         "--filter-expr 'all() - test(=cmd::tuto::fixture) - test(=cmd::publish::fixture)'";
     });

--- a/nix/buffrs.nix
+++ b/nix/buffrs.nix
@@ -37,5 +37,16 @@ in {
 
     # Audit licenses
     buffrs-deny = craneLib.cargoDeny { inherit src; };
+
+    # Rust unit and integration tests
+    buffers-nextest = craneLib.cargoNextest (commonArgs // {
+      inherit cargoArtifacts;
+      partitions = 1;
+      partitionType = "count";
+      # Ignore tutorial and publish tests because they need TLS certificates 
+      # which doens't yet work in our next setup
+      cargoNextestExtraArgs =
+        "--filter-expr 'all() - test(=cmd::tuto::fixture) - test(=cmd::publish::fixture)'";
+    });
   };
 }


### PR DESCRIPTION
Rust tests weren't current running as part of nix checks. This PR adds `nextest` to our nix checks run.

I ignored two of the integration tests which require CA root certificates to be setup because they'll need extra changes and I wanted to keep the PRs small. Another PR will follow 