### PR TITLE
Fix Clippy warnings

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,10 +3,6 @@ use miette::Diagnostic;
 use crate::ManagedFile;
 
 #[derive(thiserror::Error, Diagnostic, Debug)]
-#[error("environment variable {0} is not set")]
-pub(crate) struct EnvVarNotSet(pub &'static str);
-
-#[derive(thiserror::Error, Diagnostic, Debug)]
 #[error("failed to determine if {0} file exists")]
 pub(crate) struct FileExistsError(pub &'static str);
 

--- a/src/registry/cache.rs
+++ b/src/registry/cache.rs
@@ -16,15 +16,9 @@ use std::path::PathBuf;
 
 use bytes::Bytes;
 use miette::{miette, Context, IntoDiagnostic};
-use semver::VersionReq;
-use thiserror::Error;
 use tokio::fs;
 
 use crate::{manifest::Dependency, package::Package};
-
-#[derive(Error, Debug)]
-#[error("{0} is not a supported version requirement")]
-struct UnsupportedVersionRequirement(VersionReq);
 
 /// A registry that stores and retries packages from a local file system.
 /// This registry is intended primarily for testing.

--- a/tests/cmd/tuto/in/main.rs
+++ b/tests/cmd/tuto/in/main.rs
@@ -2,6 +2,7 @@ mod protos {
     tonic::include_proto!("buffrs");
 }
 
+#[allow(dead_code)]
 struct Sensor;
 
 impl protos::sensor_api::sensor_server::Sensor for Sensor {


### PR DESCRIPTION
Fixing some clippy warnings that are causing CI failures.

None of these seem to appear in public API so they shouldn't need a version bump