### PR TITLE
buffrs add now accept dependency with no version and defaults to `latest`

### DIFF
--- a/docs/src/commands/buffrs-add.md
+++ b/docs/src/commands/buffrs-add.md
@@ -18,14 +18,17 @@ The dependency should be specified with the repository, name and version
 according to the following format:
 
 ```
-<repository>/<package>@<version>
+<repository>/<package>[@<version>]
 ```
+
+Note: the version can be omitted (or set to `@latest`), in which case 
+it will default to the latest version of this artifact in the registry.
 
 The repository name should adhere to lower-kebab case (e.g. `my-buffrs-repo`).
 The package name has its own set of constraints as detailed in [Package Name
-Specification](../reference/pkgid-spec.md). The version must adhere to the
-[Semantic Version convention](https://semver.org/) (e.g. `1.2.3`) -- see [SemVer
-compatibility](../reference/semver.md) for more information.
+Specification](../reference/pkgid-spec.md). When specified, the version must 
+adhere to the [Semantic Version convention](https://semver.org/) (e.g. `1.2.3`)
+-- see [SemVer compatibility](../reference/semver.md) for more information.
 
 Currently there is no support for resolving version operators but the specific
 version has to be provided. This means `^1.0.0`, `<2.3.0`, `~2.0.0`, etc. can't
@@ -34,6 +37,6 @@ be installed, but `=1.2.3` has to be provided.
 #### Lockfile interaction
 
 Currently adding a new dependency won't automatically update the lockfile
-(`Proto.lock`). This is planned to change, but for now  follow up
+(`Proto.lock`). This is planned to change, but for now follow up
 with [`buffrs install`](buffrs-install.md) after adding a new dependency to make
 sure your lockfile is kept in sync.

--- a/src/registry/artifactory.rs
+++ b/src/registry/artifactory.rs
@@ -13,9 +13,15 @@
 // limitations under the License.
 
 use super::RegistryUri;
-use crate::{credentials::Credentials, manifest::Dependency, package::Package};
+use crate::{
+    credentials::Credentials,
+    manifest::Dependency,
+    package::{Package, PackageName},
+};
 use miette::{ensure, miette, Context, IntoDiagnostic};
 use reqwest::{Body, Method, Response};
+use semver::Version;
+use serde::Deserialize;
 use url::Url;
 
 /// The registry implementation for artifactory
@@ -63,6 +69,86 @@ impl Artifactory {
             .await
             .map(|_| ())
             .map_err(miette::Report::from)
+    }
+
+    /// Retrieves the latest version of a package by querying artifactory. Returns an error if no artifact could be found
+    pub async fn get_latest_version(
+        &self,
+        repository: String,
+        name: PackageName,
+    ) -> miette::Result<Version> {
+        // First retrieve all packages matching the given name
+        let search_query_url: Url = {
+            let mut url = self.registry.clone();
+            url.set_path("artifactory/api/search/artifact");
+            url.set_query(Some(&format!("name={}&repos={}", name, repository)));
+            url.into()
+        };
+
+        let response = self
+            .new_request(Method::GET, search_query_url)
+            .send()
+            .await?;
+        let response: reqwest::Response = response.into();
+
+        let headers = response.headers();
+        let content_type = headers
+            .get(&reqwest::header::CONTENT_TYPE)
+            .ok_or_else(|| miette!("missing content-type header"))?;
+        ensure!(
+            content_type
+                == reqwest::header::HeaderValue::from_static(
+                    "application/vnd.org.jfrog.artifactory.search.ArtifactSearchResult+json"
+                ),
+            "server response has incorrect mime type: {content_type:?}"
+        );
+
+        let response_str = response.text().await.into_diagnostic().wrap_err(miette!(
+            "unexpected error: unable to retrieve response payload"
+        ))?;
+        let parsed_response = serde_json::from_str::<ArtifactSearchResponse>(&response_str)
+            .into_diagnostic()
+            .wrap_err(miette!(
+                "unexpected error: response could not be deserialized to ArtifactSearchResponse"
+            ))?;
+
+        tracing::debug!(
+            "List of artifacts found matching the name: {:?}",
+            parsed_response
+        );
+
+        // Then from all package names retrieved from artifactory, extract the highest version number
+        let highest_version = parsed_response
+            .results
+            .iter()
+            .filter_map(|artifact_search_result| {
+                let uri = artifact_search_result.to_owned().uri;
+                let full_artifact_name = uri
+                    .split('/')
+                    .last()
+                    .map(|name_tgz| name_tgz.trim_end_matches(".tgz"));
+                let artifact_version = full_artifact_name
+                    .and_then(|name| name.split('-').last())
+                    .and_then(|version_str| Version::parse(version_str).ok());
+
+                // we double check that the artifact name matches exactly
+                let expected_artifact_name = artifact_version
+                    .clone()
+                    .map(|av| format!("{}-{}", name, av));
+                if full_artifact_name.is_some_and(|actual| {
+                    expected_artifact_name.is_some_and(|expected| expected == actual)
+                }) {
+                    artifact_version
+                } else {
+                    None
+                }
+            })
+            .max();
+
+        tracing::debug!("Highest version for artifact: {:?}", highest_version);
+        highest_version.ok_or_else(|| {
+            miette!("no version could be found on artifactory for this artifact name. Does it exist in this registry and repository?")
+        })
     }
 
     /// Downloads a package from artifactory
@@ -188,4 +274,14 @@ impl TryFrom<Response> for ValidatedResponse {
 
         value.error_for_status().into_diagnostic().map(Self)
     }
+}
+
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+struct ArtifactSearchResponse {
+    results: Vec<ArtifactSearchResult>,
+}
+
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+struct ArtifactSearchResult {
+    uri: String,
 }


### PR DESCRIPTION
Fixes #223 

In addition to the current:
```
buffrs add --registry <REGISTRY> <REPO>/<PACKAGE_NAME>@<VERSION>
```
you can now run:
```
buffrs add --registry <REGISTRY> <REPO>/<PACKAGE_NAME>
```
or:
```
buffrs add --registry <REGISTRY> <REPO>/<PACKAGE_NAME>@latest
```

In those cases, buffrs will query the registry for the existing version of the package and defaults to the latest