### PR TITLE
Store package in cache on first download

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -243,7 +243,7 @@ impl From<Package> for Entry {
 
 impl From<&Package> for Entry {
     fn from(value: &Package) -> Self {
-        let digest = value.digest();
+        let digest = value.digest(DigestAlgorithm::SHA256);
         Self(
             format!(
                 "{}.{}.{}.tgz",

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -204,8 +204,6 @@ impl Cache {
 
     /// Put a locked package in the cache
     pub async fn put(&self, entry: Entry, bytes: Bytes) -> miette::Result<()> {
-        // let entry: Entry = FileRequirement::from(package).into();
-
         let file = self.path().join(entry.filename());
 
         tokio::fs::write(&file, bytes.as_ref())
@@ -245,12 +243,13 @@ impl From<Package> for Entry {
 
 impl From<&Package> for Entry {
     fn from(value: &Package) -> Self {
+        let digest = value.digest();
         Self(
             format!(
                 "{}.{}.{}.tgz",
                 value.name(),
-                value.digest.algorithm(),
-                hex::encode(value.digest.as_bytes())
+                digest.algorithm(),
+                hex::encode(digest.as_bytes())
             )
             .into(),
         )

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -69,7 +69,7 @@ impl LockedPackage {
             name: package.name().to_owned(),
             registry,
             repository,
-            digest: DigestAlgorithm::SHA256.digest(&package.tgz),
+            digest: package.digest.to_owned(),
             version: package.version().to_owned(),
             dependencies: package
                 .manifest

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -69,7 +69,7 @@ impl LockedPackage {
             name: package.name().to_owned(),
             registry,
             repository,
-            digest: package.digest().to_owned(),
+            digest: package.digest(DigestAlgorithm::SHA256).to_owned(),
             version: package.version().to_owned(),
             dependencies: package
                 .manifest

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -69,7 +69,7 @@ impl LockedPackage {
             name: package.name().to_owned(),
             registry,
             repository,
-            digest: package.digest.to_owned(),
+            digest: package.digest().to_owned(),
             version: package.version().to_owned(),
             dependencies: package
                 .manifest

--- a/src/package/compressed.rs
+++ b/src/package/compressed.rs
@@ -39,8 +39,6 @@ pub struct Package {
     pub manifest: Manifest,
     /// The `tar.gz` archive containing the protocol buffers
     pub tgz: Bytes,
-    /// The package digest
-    pub digest: Digest,
 }
 
 impl Package {
@@ -118,11 +116,9 @@ impl Package {
             .wrap_err(miette!("failed to finalize package"))?
             .into();
 
-        let digest = DigestAlgorithm::SHA256.digest(&tgz);
         Ok(Self {
             manifest,
             tgz,
-            digest,
         })
     }
 
@@ -199,11 +195,9 @@ impl Package {
             .parse()
             .into_diagnostic()?;
 
-        let digest = DigestAlgorithm::SHA256.digest(&tgz);
         Ok(Self {
             manifest,
             tgz,
-            digest,
         })
     }
 
@@ -231,6 +225,11 @@ impl Package {
             .as_ref()
             .expect("compressed package contains invalid manifest (package section missing)")
             .version
+    }
+
+    /// Digest calculates the digest based on the downloaded package bytes
+    pub fn digest(&self) -> Digest {
+        DigestAlgorithm::SHA256.digest(&self.tgz)
     }
 
     /// Lock this package

--- a/src/package/compressed.rs
+++ b/src/package/compressed.rs
@@ -116,10 +116,7 @@ impl Package {
             .wrap_err(miette!("failed to finalize package"))?
             .into();
 
-        Ok(Self {
-            manifest,
-            tgz,
-        })
+        Ok(Self { manifest, tgz })
     }
 
     /// Unpack a package to a specific path.
@@ -195,10 +192,7 @@ impl Package {
             .parse()
             .into_diagnostic()?;
 
-        Ok(Self {
-            manifest,
-            tgz,
-        })
+        Ok(Self { manifest, tgz })
     }
 
     /// The name of this package

--- a/src/package/compressed.rs
+++ b/src/package/compressed.rs
@@ -222,8 +222,8 @@ impl Package {
     }
 
     /// Digest calculates the digest based on the downloaded package bytes
-    pub fn digest(&self) -> Digest {
-        DigestAlgorithm::SHA256.digest(&self.tgz)
+    pub fn digest(&self, algorithm: DigestAlgorithm) -> Digest {
+        algorithm.digest(&self.tgz)
     }
 
     /// Lock this package

--- a/src/registry/cache.rs
+++ b/src/registry/cache.rs
@@ -91,6 +91,7 @@ impl LocalRegistry {
 #[cfg(test)]
 mod tests {
     use crate::{
+        lock::DigestAlgorithm,
         manifest::{Dependency, Manifest, PackageManifest},
         package::{Package, PackageType},
         registry::cache::LocalRegistry,
@@ -122,6 +123,7 @@ mod tests {
         registry
             .publish(
                 Package {
+                    digest: DigestAlgorithm::SHA256.digest(&package_bytes),
                     manifest: manifest.clone(),
                     tgz: package_bytes.clone(),
                 },

--- a/src/registry/cache.rs
+++ b/src/registry/cache.rs
@@ -91,7 +91,6 @@ impl LocalRegistry {
 #[cfg(test)]
 mod tests {
     use crate::{
-        lock::DigestAlgorithm,
         manifest::{Dependency, Manifest, PackageManifest},
         package::{Package, PackageType},
         registry::cache::LocalRegistry,
@@ -123,7 +122,6 @@ mod tests {
         registry
             .publish(
                 Package {
-                    digest: DigestAlgorithm::SHA256.digest(&package_bytes),
                     manifest: manifest.clone(),
                     tgz: package_bytes.clone(),
                 },


### PR DESCRIPTION
Fixes #258

Allow packages to be stored in the cache on their first download by calculating the hash as soon as they are fetched. 