### PR TITLE
issue-176: add lint to keep service defs out of lib type packages

### DIFF
--- a/src/validation/rules.rs
+++ b/src/validation/rules.rs
@@ -14,8 +14,11 @@
 
 use std::fmt::Debug;
 
+use lib_package::LibPackage;
+
 use crate::{
     manifest::PackageManifest,
+    package::PackageType,
     validation::{
         data::*,
         violation::{self, *},
@@ -23,6 +26,7 @@ use crate::{
 };
 
 mod ident_casing;
+mod lib_package;
 mod package_name;
 
 pub use self::{ident_casing::*, package_name::*};
@@ -104,8 +108,57 @@ impl Rule for RuleSet {
 
 /// Get default rules for a given `buffrs` package name.
 pub fn all(manifest: &PackageManifest) -> RuleSet {
-    vec![
+    let mut ret: Vec<Box<dyn Rule>> = vec![
         Box::new(PackageName::new(manifest.name.clone())),
         Box::new(IdentCasing),
-    ]
+    ];
+
+    if manifest.kind == PackageType::Lib {
+        ret.push(Box::new(LibPackage));
+    }
+
+    ret
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::package::PackageType;
+    use semver::Version;
+
+    #[test]
+    fn all_should_not_contain_libpackage_rule_for_api_type_packages(
+    ) -> Result<(), Box<dyn core::error::Error>> {
+        let manifest = PackageManifest {
+            kind: PackageType::Api,
+            name: crate::package::PackageName::new("package")?,
+            version: Version::new(0, 1, 0),
+            description: Default::default(),
+        };
+
+        let all = all(&manifest);
+        assert!(all
+            .iter()
+            .all(|rule| rule.rule_name() != LibPackage.rule_name()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn all_should_contain_libpackage_rule_for_lib_type_packages(
+    ) -> Result<(), Box<dyn core::error::Error>> {
+        let manifest = PackageManifest {
+            kind: PackageType::Lib,
+            name: crate::package::PackageName::new("package")?,
+            version: Version::new(0, 1, 0),
+            description: Default::default(),
+        };
+
+        let all = all(&manifest);
+        assert!(all
+            .iter()
+            .any(|rule| rule.rule_name() == LibPackage.rule_name()));
+
+        Ok(())
+    }
 }

--- a/src/validation/rules.rs
+++ b/src/validation/rules.rs
@@ -128,7 +128,7 @@ mod tests {
 
     #[test]
     fn all_should_not_contain_libpackage_rule_for_api_type_packages(
-    ) -> Result<(), Box<dyn core::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let manifest = PackageManifest {
             kind: PackageType::Api,
             name: crate::package::PackageName::new("package")?,
@@ -146,7 +146,7 @@ mod tests {
 
     #[test]
     fn all_should_contain_libpackage_rule_for_lib_type_packages(
-    ) -> Result<(), Box<dyn core::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let manifest = PackageManifest {
             kind: PackageType::Lib,
             name: crate::package::PackageName::new("package")?,

--- a/src/validation/rules/lib_package.rs
+++ b/src/validation/rules/lib_package.rs
@@ -1,0 +1,80 @@
+use super::*;
+
+#[derive(Debug, Clone, Copy)]
+pub struct LibPackage;
+
+impl Rule for LibPackage {
+    fn rule_info(&self) -> &'static str {
+        "Make sure that lib packages don't contain service definitions."
+    }
+
+    fn rule_level(&self) -> Level {
+        Level::Warning
+    }
+
+    fn check_package(&mut self, package: &Package) -> Violations {
+        let package_name = &package.name;
+        package
+            .entities
+            .iter()
+            .filter_map(|(name, entity)| {
+                if let Entity::Service(_) = entity {
+                    let message = violation::Message {
+                        message: format!("{name} is a service definition but {package_name} is a lib type package and thus shouldn't contain services."),
+                        help: "It's best to keep packages containing services separate from packages containing messages and enums.".into(),
+                    };
+                    Some(self.to_violation(message))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    #[test]
+    fn should_complain_about_service_defs() {
+        let entities = {
+            let mut ret: BTreeMap<String, Entity> = BTreeMap::new();
+            ret.insert("service A".into(), Entity::Service(Service {}));
+            ret.insert("service B".into(), Entity::Service(Service {}));
+
+            ret
+        };
+
+        let package = Package {
+            name: "my package".into(),
+            files: vec!["ignored.proto".into()],
+            entities,
+        };
+
+        let violations = LibPackage.check_package(&package);
+
+        let help = "It's best to keep packages containing services separate from packages containing messages and enums.";
+        let violation_1 = Violation {
+            rule: "LibPackage".into(),
+            level: Level::Warning,
+            message: violation::Message {
+                message: "service A is a service definition but my package is a lib type package and thus shouldn't contain services.".into(),
+                help: help.into(),
+            },
+            location: Default::default(),
+            info: LibPackage.rule_info().into(),
+        };
+        let violation_2 = Violation {
+            message: violation::Message {
+                message: "service B is a service definition but my package is a lib type package and thus shouldn't contain services.".into(),
+                help: help.into(),
+            },
+            ..violation_1.clone()
+        };
+
+        assert_eq!(violations, vec![violation_1, violation_2]);
+    }
+}

--- a/src/validation/rules/lib_package.rs
+++ b/src/validation/rules/lib_package.rs
@@ -9,7 +9,7 @@ impl Rule for LibPackage {
     }
 
     fn rule_level(&self) -> Level {
-        Level::Warning
+        Level::Error
     }
 
     fn check_package(&mut self, package: &Package) -> Violations {
@@ -59,7 +59,7 @@ mod tests {
         let help = "It's best to keep packages containing services separate from packages containing messages and enums.";
         let violation_1 = Violation {
             rule: "LibPackage".into(),
-            level: Level::Warning,
+            level: Level::Error,
             message: violation::Message {
                 message: "service A is a service definition but my package is a lib type package and thus shouldn't contain services.".into(),
                 help: help.into(),


### PR DESCRIPTION
Addressing one of the todos in #176: add a lint for lib type packages emitting a warning when the packages declares any services.

<img width="893" alt="Screenshot 2024-08-07 at 18 55 21" src="https://github.com/user-attachments/assets/4158f8ac-7c9f-4310-a15e-827064aaee60">
