### PR TITLE
Update crane version to latest

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,12 @@
       }
     },
     "crane": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
       "locked": {
-        "lastModified": 1713459701,
-        "narHash": "sha256-LjQ11ASxnv/FXfb8QnrIyMkyqSqcBPX+lFK8gu0jSQE=",
+        "lastModified": 1727060013,
+        "narHash": "sha256-/fC5YlJy4IoAW9GhkJiwyzk0K/gQd9Qi4rRcoweyG9E=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "45ea0059fb325132fdc3c39faffb0941d25d08d3",
+        "rev": "6b40cc876c929bfe1e3a24bf538ce3b5622646ba",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,10 +2,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/nix/buffrs.nix
+++ b/nix/buffrs.nix
@@ -1,7 +1,7 @@
-{ pkgs, crane, rustToolchain, system, advisory-db, buildInputs
+{ pkgs, crane, rustToolchain, advisory-db, buildInputs
 , nativeBuildInputs, buildEnvVars }:
 let
-  craneLib = crane.lib.${system}.overrideToolchain rustToolchain;
+  craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
   src = ../.;
 
   # Common arguments can be set here to avoid repeating them later

--- a/nix/buffrs.nix
+++ b/nix/buffrs.nix
@@ -1,5 +1,5 @@
-{ pkgs, crane, rustToolchain, advisory-db, buildInputs
-, nativeBuildInputs, buildEnvVars }:
+{ pkgs, crane, rustToolchain, advisory-db, buildInputs, nativeBuildInputs
+, buildEnvVars }:
 let
   craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
   src = ../.;


### PR DESCRIPTION
Hello! In newer `crane` versions, `crane.lib.${system}` has been removed; so I'm creating this PR to:
- Replace the `crane.lib.${system}` usage with the equivalent `(crane.mkLib pkgs)`
- Update the `crane` version