### PR TITLE
Keeping files "last modified" time to enable change detection in build.rs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,6 @@
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-utils.follows = "flake-utils";
     };
     advisory-db = {
       url = "github:rustsec/advisory-db";

--- a/src/package/store.rs
+++ b/src/package/store.rs
@@ -152,7 +152,11 @@ impl PackageStore {
     }
 
     /// Packages a release from the local file system state
-    pub async fn release(&self, manifest: &Manifest) -> miette::Result<Package> {
+    pub async fn release(
+        &self,
+        manifest: &Manifest,
+        preserve_mtime: bool,
+    ) -> miette::Result<Package> {
         for dependency in manifest.dependencies.iter() {
             let resolved = self.resolve(&dependency.package).await?;
 
@@ -182,7 +186,7 @@ impl PackageStore {
             );
         }
 
-        let package = Package::create(manifest.clone(), entries)?;
+        let package = Package::create(manifest.clone(), entries, preserve_mtime)?;
 
         tracing::info!(":: packaged {}@{}", package.name(), package.version());
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -102,6 +102,37 @@ struct DownloadError {
     version: VersionReq,
 }
 
+struct ProcessDependency<'a> {
+    name: PackageName,
+    dependency: Dependency,
+    is_root: bool,
+    lockfile: &'a Lockfile,
+    credentials: &'a Arc<Credentials>,
+    cache: &'a Cache,
+    preserve_mtime: bool,
+}
+
+struct ProcessLocalDependency<'a> {
+    name: PackageName,
+    dependency: LocalDependency,
+    #[allow(dead_code)]
+    is_root: bool,
+    lockfile: &'a Lockfile,
+    credentials: &'a Arc<Credentials>,
+    cache: &'a Cache,
+    preserve_mtime: bool,
+}
+
+struct ProcessRemoteDependency<'a> {
+    name: PackageName,
+    dependency: RemoteDependency,
+    is_root: bool,
+    lockfile: &'a Lockfile,
+    credentials: &'a Arc<Credentials>,
+    cache: &'a Cache,
+    preserve_mtime: bool,
+}
+
 impl DependencyGraph {
     /// Recursively resolves dependencies from the manifest to build a dependency graph
     pub async fn from_manifest(
@@ -121,14 +152,16 @@ impl DependencyGraph {
 
         for dependency in &manifest.dependencies {
             Self::process_dependency(
-                name.clone(),
-                dependency.clone(),
-                true,
-                lockfile,
-                credentials,
-                cache,
                 &mut entries,
-                preserve_mtime,
+                ProcessDependency {
+                    name: name.clone(),
+                    dependency: dependency.clone(),
+                    is_root: true,
+                    lockfile,
+                    credentials,
+                    cache,
+                    preserve_mtime,
+                },
             )
             .await?;
         }
@@ -137,45 +170,52 @@ impl DependencyGraph {
     }
 
     async fn process_dependency(
-        name: PackageName,
-        dependency: Dependency,
-        is_root: bool,
-        lockfile: &Lockfile,
-        credentials: &Arc<Credentials>,
-        cache: &Cache,
         entries: &mut HashMap<PackageName, ResolvedDependency>,
-        preserve_mtime: bool,
+        params: ProcessDependency<'_>,
     ) -> miette::Result<()> {
+        let ProcessDependency {
+            name,
+            dependency,
+            is_root,
+            lockfile,
+            credentials,
+            cache,
+            preserve_mtime,
+        } = params;
         match dependency.manifest {
             DependencyManifest::Remote(manifest) => {
                 Self::process_remote_dependency(
-                    name.clone(),
-                    RemoteDependency {
-                        package: dependency.package,
-                        manifest,
-                    },
-                    is_root,
-                    lockfile,
-                    credentials,
-                    cache,
                     entries,
-                    preserve_mtime,
+                    ProcessRemoteDependency {
+                        name: name.clone(),
+                        dependency: RemoteDependency {
+                            package: dependency.package,
+                            manifest,
+                        },
+                        is_root,
+                        lockfile,
+                        credentials,
+                        cache,
+                        preserve_mtime,
+                    },
                 )
                 .await?;
             }
             DependencyManifest::Local(manifest) => {
                 Self::process_local_dependency(
-                    name.clone(),
-                    LocalDependency {
-                        package: dependency.package,
-                        manifest,
-                    },
-                    is_root,
-                    lockfile,
-                    credentials,
-                    cache,
                     entries,
-                    preserve_mtime,
+                    ProcessLocalDependency {
+                        name: name.clone(),
+                        dependency: LocalDependency {
+                            package: dependency.package,
+                            manifest,
+                        },
+                        is_root,
+                        lockfile,
+                        credentials,
+                        cache,
+                        preserve_mtime,
+                    },
                 )
                 .await?;
             }
@@ -185,16 +225,19 @@ impl DependencyGraph {
     }
 
     #[async_recursion]
-    async fn process_local_dependency(
-        name: PackageName,
-        dependency: LocalDependency,
-        _: bool,
-        lockfile: &Lockfile,
-        credentials: &Arc<Credentials>,
-        cache: &Cache,
-        entries: &mut HashMap<PackageName, ResolvedDependency>,
-        preserve_mtime: bool,
+    async fn process_local_dependency<'a>(
+        entries: &'a mut HashMap<PackageName, ResolvedDependency>,
+        params: ProcessLocalDependency<'a>,
     ) -> miette::Result<()> {
+        let ProcessLocalDependency {
+            name,
+            dependency,
+            is_root: _,
+            lockfile,
+            credentials,
+            cache,
+            preserve_mtime,
+        } = params;
         let manifest = Manifest::try_read_from(&dependency.manifest.path.join(MANIFEST_FILE))
             .await?
             .ok_or_else(|| {
@@ -231,14 +274,16 @@ impl DependencyGraph {
 
         for sub_dependency in sub_dependencies {
             Self::process_dependency(
-                dependency_name.clone(),
-                sub_dependency,
-                false,
-                lockfile,
-                credentials,
-                cache,
                 entries,
-                preserve_mtime,
+                ProcessDependency {
+                    name: dependency_name.clone(),
+                    dependency: sub_dependency,
+                    is_root: false,
+                    lockfile,
+                    credentials,
+                    cache,
+                    preserve_mtime,
+                },
             )
             .await?;
         }
@@ -247,16 +292,19 @@ impl DependencyGraph {
     }
 
     #[async_recursion]
-    async fn process_remote_dependency(
-        name: PackageName,
-        dependency: RemoteDependency,
-        is_root: bool,
-        lockfile: &Lockfile,
-        credentials: &Arc<Credentials>,
-        cache: &Cache,
-        entries: &mut HashMap<PackageName, ResolvedDependency>,
-        preserve_mtime: bool,
+    async fn process_remote_dependency<'a>(
+        entries: &'a mut HashMap<PackageName, ResolvedDependency>,
+        params: ProcessRemoteDependency<'a>,
     ) -> miette::Result<()> {
+        let ProcessRemoteDependency {
+            name,
+            dependency,
+            is_root,
+            lockfile,
+            credentials,
+            cache,
+            preserve_mtime,
+        } = params;
         let version_req = dependency.manifest.version.clone();
 
         if let Some(entry) = entries.get_mut(&dependency.package) {
@@ -315,14 +363,16 @@ impl DependencyGraph {
 
             for sub_dependency in sub_dependencies {
                 Self::process_dependency(
-                    dependency_name.clone(),
-                    sub_dependency,
-                    false,
-                    lockfile,
-                    credentials,
-                    cache,
                     entries,
-                    preserve_mtime,
+                    ProcessDependency {
+                        name: dependency_name.clone(),
+                        dependency: sub_dependency,
+                        is_root: false,
+                        lockfile,
+                        credentials,
+                        cache,
+                        preserve_mtime,
+                    },
                 )
                 .await?;
             }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -109,6 +109,7 @@ impl DependencyGraph {
         lockfile: &Lockfile,
         credentials: &Arc<Credentials>,
         cache: &Cache,
+        preserve_mtime: bool,
     ) -> miette::Result<Self> {
         let name = manifest
             .package
@@ -127,6 +128,7 @@ impl DependencyGraph {
                 credentials,
                 cache,
                 &mut entries,
+                preserve_mtime,
             )
             .await?;
         }
@@ -142,6 +144,7 @@ impl DependencyGraph {
         credentials: &Arc<Credentials>,
         cache: &Cache,
         entries: &mut HashMap<PackageName, ResolvedDependency>,
+        preserve_mtime: bool,
     ) -> miette::Result<()> {
         match dependency.manifest {
             DependencyManifest::Remote(manifest) => {
@@ -156,6 +159,7 @@ impl DependencyGraph {
                     credentials,
                     cache,
                     entries,
+                    preserve_mtime,
                 )
                 .await?;
             }
@@ -171,6 +175,7 @@ impl DependencyGraph {
                     credentials,
                     cache,
                     entries,
+                    preserve_mtime,
                 )
                 .await?;
             }
@@ -188,6 +193,7 @@ impl DependencyGraph {
         credentials: &Arc<Credentials>,
         cache: &Cache,
         entries: &mut HashMap<PackageName, ResolvedDependency>,
+        preserve_mtime: bool,
     ) -> miette::Result<()> {
         let manifest = Manifest::try_read_from(&dependency.manifest.path.join(MANIFEST_FILE))
             .await?
@@ -201,7 +207,7 @@ impl DependencyGraph {
             })?;
 
         let store = PackageStore::open(&dependency.manifest.path).await?;
-        let package = store.release(&manifest).await?;
+        let package = store.release(&manifest, preserve_mtime).await?;
 
         let dependency_name = package.name().clone();
         let sub_dependencies = package.manifest.dependencies.clone();
@@ -232,6 +238,7 @@ impl DependencyGraph {
                 credentials,
                 cache,
                 entries,
+                preserve_mtime,
             )
             .await?;
         }
@@ -248,6 +255,7 @@ impl DependencyGraph {
         credentials: &Arc<Credentials>,
         cache: &Cache,
         entries: &mut HashMap<PackageName, ResolvedDependency>,
+        preserve_mtime: bool,
     ) -> miette::Result<()> {
         let version_req = dependency.manifest.version.clone();
 
@@ -314,6 +322,7 @@ impl DependencyGraph {
                     credentials,
                     cache,
                     entries,
+                    preserve_mtime,
                 )
                 .await?;
             }


### PR DESCRIPTION
Most codegen tools (list prost or tonic) are trying to detect if the proto files changed (with things like `println!("cargo:rerun-if-changed={}", proto);`), which is based on the last modification time of a file.

In the current situation, all files added to a buffrs `Package` are stripped from their modification time (it is set to EPOCH by `tar`), so `build.rs` like scripts can't detect if a file changed or not after calling `buffrs install`.

In this PR, I keep the mtime around to fix this situation and enable builder to only to the codegen when necessary.

Some design decisions:
- Do we want this for the manifest files too ? For now, only the proto files have their mtime kept around
- Do we want an option to `buffrs package` to select if we preserve or not the mtime ?
- If we want such an option, what default should we use (I vote to "preserve" by default, like tar: https://docs.rs/tar/latest/tar/struct.Archive.html#method.set_preserve_mtime)
