### PR TITLE
feat(publish): skip publishing if the package is already there

### DIFF
--- a/tests/cmd/publish/already_published/in
+++ b/tests/cmd/publish/already_published/in
@@ -1,0 +1,1 @@
+../../../data/projects/lib

--- a/tests/cmd/publish/already_published/mod.rs
+++ b/tests/cmd/publish/already_published/mod.rs
@@ -1,0 +1,35 @@
+use crate::{VirtualFileSystem, with_test_registry};
+
+#[test]
+fn fixture() {
+    with_test_registry(|url| {
+        let vfs = VirtualFileSystem::copy(crate::parent_directory!().join("in"));
+
+        crate::cli!()
+            .arg("publish")
+            .arg("--registry")
+            .arg(url)
+            .arg("--repository")
+            .arg("my-repository")
+            .current_dir(vfs.root())
+            .assert()
+            .success()
+            .stdout(include_str!("stdout0.log"))
+            .stderr(include_str!("stderr.log"));
+
+        // publish a second time to test duplicate detection
+        crate::cli!()
+            .arg("publish")
+            .arg("--registry")
+            .arg(url)
+            .arg("--repository")
+            .arg("my-repository")
+            .current_dir(vfs.root())
+            .assert()
+            .success()
+            .stdout(include_str!("stdout1.log"))
+            .stderr(include_str!("stderr.log"));
+
+        vfs.verify_against(crate::parent_directory!().join("out"));
+    });
+}

--- a/tests/cmd/publish/already_published/out
+++ b/tests/cmd/publish/already_published/out
@@ -1,0 +1,1 @@
+../../../data/projects/lib

--- a/tests/cmd/publish/already_published/stdout0.log
+++ b/tests/cmd/publish/already_published/stdout0.log
@@ -1,0 +1,2 @@
+:: packaged lib@0.0.1
+:: published my-repository/lib@0.0.1

--- a/tests/cmd/publish/already_published/stdout1.log
+++ b/tests/cmd/publish/already_published/stdout1.log
@@ -1,0 +1,2 @@
+:: packaged lib@0.0.1
+:: my-repository/lib@0.0.1 is already published, skipping

--- a/tests/cmd/publish/mod.rs
+++ b/tests/cmd/publish/mod.rs
@@ -1,2 +1,3 @@
+mod already_published;
 mod lib;
 mod local;


### PR DESCRIPTION
Publishing the same package twice currently triggers a hard error (usually a 403). If the package is there, let's call it a success 