### PR TITLE
Repair publishing for complex workspaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1446,9 +1446,9 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,7 +238,7 @@ dependencies = [
 
 [[package]]
 name = "buffrs"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,9 +1627,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buffrs"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 description = "Modern protobuf package management"
 authors = [

--- a/src/operations/publish.rs
+++ b/src/operations/publish.rs
@@ -474,7 +474,8 @@ impl Publisher {
             manifest_override.is_some()
         );
 
-        let manifest_path = fs::canonicalize(package_path.join(MANIFEST_FILE))
+        let manifest_path = tokio::fs::canonicalize(package_path.join(MANIFEST_FILE))
+            .await
             .into_diagnostic()
             .wrap_err_with(|| {
                 format!(
@@ -552,7 +553,7 @@ impl Publisher {
         }
 
         let remote_dependencies =
-            self.replace_local_with_remote_dependencies(&manifest, package_path)?;
+            self.replace_local_with_remote_dependencies(&manifest, package_path).await?;
         tracing::debug!(
             "local dependencies replaced successfully, now have {} total remote dependencies",
             remote_dependencies.len()
@@ -628,7 +629,7 @@ impl Publisher {
     }
 
     /// Replaces local dependencies in a manifest with their published remote versions
-    fn replace_local_with_remote_dependencies(
+    async fn replace_local_with_remote_dependencies(
         &self,
         manifest: &PackagesManifest,
         base_path: &Path,
@@ -778,8 +779,8 @@ mod tests {
         tmp
     }
 
-    #[test]
-    fn test_replace_local_with_remote_single_dependency() {
+    #[tokio::test]
+    async fn test_replace_local_with_remote_single_dependency() {
         let tmp = create_workspace_dirs(&["project", "local-lib"]);
         let mut publisher = create_test_publisher();
         let base_path = tmp.path().join("project");
@@ -807,6 +808,7 @@ mod tests {
 
         let result = publisher
             .replace_local_with_remote_dependencies(&manifest, &base_path)
+            .await
             .unwrap();
 
         assert_eq!(result.len(), 1);
@@ -820,8 +822,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_replace_local_with_remote_multiple_dependencies() {
+    #[tokio::test]
+    async fn test_replace_local_with_remote_multiple_dependencies() {
         let tmp = create_workspace_dirs(&["project", "lib1", "lib2"]);
         let mut publisher = create_test_publisher();
         let base_path = tmp.path().join("project");
@@ -866,6 +868,7 @@ mod tests {
 
         let result = publisher
             .replace_local_with_remote_dependencies(&manifest, &base_path)
+            .await
             .unwrap();
 
         assert_eq!(result.len(), 2);
@@ -873,8 +876,8 @@ mod tests {
         assert_eq!(result[1].package, PackageName::unchecked("lib2"));
     }
 
-    #[test]
-    fn test_replace_local_with_remote_missing_mapping_fails() {
+    #[tokio::test]
+    async fn test_replace_local_with_remote_missing_mapping_fails() {
         let tmp = create_workspace_dirs(&["project", "missing-lib"]);
         let publisher = create_test_publisher();
         let base_path = tmp.path().join("project");
@@ -888,7 +891,9 @@ mod tests {
             }])
             .build();
 
-        let result = publisher.replace_local_with_remote_dependencies(&manifest, &base_path);
+        let result = publisher
+            .replace_local_with_remote_dependencies(&manifest, &base_path)
+            .await;
 
         assert!(result.is_err());
         let err_msg = format!("{:?}", result.unwrap_err());
@@ -896,8 +901,8 @@ mod tests {
         assert!(err_msg.contains("should have been made available"));
     }
 
-    #[test]
-    fn test_replace_preserves_remote_dependencies() {
+    #[tokio::test]
+    async fn test_replace_preserves_remote_dependencies() {
         let tmp = create_workspace_dirs(&["project", "local-lib"]);
         let mut publisher = create_test_publisher();
         let base_path = tmp.path().join("project");
@@ -936,6 +941,7 @@ mod tests {
 
         let result = publisher
             .replace_local_with_remote_dependencies(&manifest, &base_path)
+            .await
             .unwrap();
 
         assert_eq!(result.len(), 2);
@@ -950,8 +956,8 @@ mod tests {
         assert_eq!(result[1].package, PackageName::unchecked("local-lib"));
     }
 
-    #[test]
-    fn test_empty_dependencies_returns_empty() {
+    #[tokio::test]
+    async fn test_empty_dependencies_returns_empty() {
         let tmp = create_workspace_dirs(&["project"]);
         let publisher = create_test_publisher();
         let base_path = tmp.path().join("project");
@@ -962,6 +968,7 @@ mod tests {
 
         let result = publisher
             .replace_local_with_remote_dependencies(&manifest, &base_path)
+            .await
             .unwrap();
 
         assert_eq!(result.len(), 0);

--- a/src/operations/publish.rs
+++ b/src/operations/publish.rs
@@ -665,19 +665,18 @@ impl Publisher {
                     );
 
                     // Paths in the manifest are relative and need to be canonicalized to be used as unique keys
-                    let canonical_path = fs::canonicalize(
-                        base_path.join(&local_manifest.path).join(MANIFEST_FILE),
-                    )
-                    .into_diagnostic()
-                    .wrap_err_with(|| {
-                        format!(
-                            "failed to canonicalize dependency path: {}",
-                            base_path
-                                .join(&local_manifest.path)
-                                .join(MANIFEST_FILE)
-                                .display()
-                        )
-                    })?;
+                    let canonical_path =
+                        fs::canonicalize(base_path.join(&local_manifest.path).join(MANIFEST_FILE))
+                            .into_diagnostic()
+                            .wrap_err_with(|| {
+                                format!(
+                                    "failed to canonicalize dependency path: {}",
+                                    base_path
+                                        .join(&local_manifest.path)
+                                        .join(MANIFEST_FILE)
+                                        .display()
+                                )
+                            })?;
                     let absolute_path_manifest = LocalDependencyManifest {
                         path: canonical_path,
                     };

--- a/src/operations/publish.rs
+++ b/src/operations/publish.rs
@@ -769,14 +769,25 @@ mod tests {
         }
     }
 
+    /// Creates a temp workspace directory structure with Proto.toml files.
+    fn create_workspace_dirs(dirs: &[&str]) -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        for dir in dirs {
+            let pkg_dir = tmp.path().join(dir);
+            fs::create_dir_all(&pkg_dir).unwrap();
+            fs::write(pkg_dir.join(MANIFEST_FILE), "").unwrap();
+        }
+        tmp
+    }
+
     #[test]
     fn test_replace_local_with_remote_single_dependency() {
+        let tmp = create_workspace_dirs(&["project", "local-lib"]);
         let mut publisher = create_test_publisher();
-        let base_path = PathBuf::from("/project");
+        let base_path = tmp.path().join("project");
 
-        // Setup: Add a mapping for a local dependency
         let local_manifest = LocalDependencyManifest {
-            path: base_path.join("../local-lib").join(MANIFEST_FILE),
+            path: fs::canonicalize(base_path.join("../local-lib").join(MANIFEST_FILE)).unwrap(),
         };
         let remote_manifest = RemoteDependencyManifest {
             registry: RegistryUri::from_str("https://test.registry.com").unwrap(),
@@ -785,9 +796,8 @@ mod tests {
         };
         publisher
             .manifest_mappings
-            .insert(local_manifest.clone(), remote_manifest.clone());
+            .insert(local_manifest, remote_manifest);
 
-        // Create a manifest with a local dependency
         let manifest = PackagesManifest::builder()
             .dependencies(vec![Dependency {
                 package: PackageName::unchecked("local-lib"),
@@ -797,12 +807,10 @@ mod tests {
             }])
             .build();
 
-        // Test: Replace local with remote
         let result = publisher
             .replace_local_with_remote_dependencies(&manifest, &base_path)
             .unwrap();
 
-        // Verify: Should have one remote dependency
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].package, PackageName::unchecked("local-lib"));
         match &result[0].manifest {
@@ -816,12 +824,12 @@ mod tests {
 
     #[test]
     fn test_replace_local_with_remote_multiple_dependencies() {
+        let tmp = create_workspace_dirs(&["project", "lib1", "lib2"]);
         let mut publisher = create_test_publisher();
-        let base_path = PathBuf::from("/project");
+        let base_path = tmp.path().join("project");
 
-        // Setup: Add mappings for two local dependencies
         let local1 = LocalDependencyManifest {
-            path: base_path.join("../lib1").join(MANIFEST_FILE),
+            path: fs::canonicalize(base_path.join("../lib1").join(MANIFEST_FILE)).unwrap(),
         };
         let remote1 = RemoteDependencyManifest {
             registry: RegistryUri::from_str("https://test.registry.com").unwrap(),
@@ -830,7 +838,7 @@ mod tests {
         };
 
         let local2 = LocalDependencyManifest {
-            path: base_path.join("../lib2").join(MANIFEST_FILE),
+            path: fs::canonicalize(base_path.join("../lib2").join(MANIFEST_FILE)).unwrap(),
         };
         let remote2 = RemoteDependencyManifest {
             registry: RegistryUri::from_str("https://test.registry.com").unwrap(),
@@ -841,7 +849,6 @@ mod tests {
         publisher.manifest_mappings.insert(local1, remote1);
         publisher.manifest_mappings.insert(local2, remote2);
 
-        // Create manifest with two local dependencies
         let manifest = PackagesManifest::builder()
             .dependencies(vec![
                 Dependency {
@@ -859,12 +866,10 @@ mod tests {
             ])
             .build();
 
-        // Test
         let result = publisher
             .replace_local_with_remote_dependencies(&manifest, &base_path)
             .unwrap();
 
-        // Verify: Both dependencies replaced
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].package, PackageName::unchecked("lib1"));
         assert_eq!(result[1].package, PackageName::unchecked("lib2"));
@@ -872,10 +877,10 @@ mod tests {
 
     #[test]
     fn test_replace_local_with_remote_missing_mapping_fails() {
+        let tmp = create_workspace_dirs(&["project", "missing-lib"]);
         let publisher = create_test_publisher();
-        let base_path = PathBuf::from("/project");
+        let base_path = tmp.path().join("project");
 
-        // Create manifest with local dependency but NO mapping
         let manifest = PackagesManifest::builder()
             .dependencies(vec![Dependency {
                 package: PackageName::unchecked("missing-lib"),
@@ -885,7 +890,6 @@ mod tests {
             }])
             .build();
 
-        // Test: Should fail
         let result = publisher.replace_local_with_remote_dependencies(&manifest, &base_path);
 
         assert!(result.is_err());
@@ -896,12 +900,12 @@ mod tests {
 
     #[test]
     fn test_replace_preserves_remote_dependencies() {
+        let tmp = create_workspace_dirs(&["project", "local-lib"]);
         let mut publisher = create_test_publisher();
-        let base_path = PathBuf::from("/project");
+        let base_path = tmp.path().join("project");
 
-        // Setup: Add mapping for local dep
         let local_manifest = LocalDependencyManifest {
-            path: base_path.join("../local-lib").join(MANIFEST_FILE),
+            path: fs::canonicalize(base_path.join("../local-lib").join(MANIFEST_FILE)).unwrap(),
         };
         let remote_manifest = RemoteDependencyManifest {
             registry: RegistryUri::from_str("https://test.registry.com").unwrap(),
@@ -910,9 +914,8 @@ mod tests {
         };
         publisher
             .manifest_mappings
-            .insert(local_manifest, remote_manifest.clone());
+            .insert(local_manifest, remote_manifest);
 
-        // Create manifest with both local AND remote dependencies
         let existing_remote = Dependency {
             package: PackageName::unchecked("existing-remote"),
             manifest: DependencyManifest::Remote(RemoteDependencyManifest {
@@ -930,18 +933,14 @@ mod tests {
         };
 
         let manifest = PackagesManifest::builder()
-            .dependencies(vec![existing_remote.clone(), local_dep])
+            .dependencies(vec![existing_remote, local_dep])
             .build();
 
-        // Test
         let result = publisher
             .replace_local_with_remote_dependencies(&manifest, &base_path)
             .unwrap();
 
-        // Verify: Should have both remote deps (existing + converted)
         assert_eq!(result.len(), 2);
-
-        // First one should be the existing remote (unchanged)
         assert_eq!(result[0].package, PackageName::unchecked("existing-remote"));
         match &result[0].manifest {
             DependencyManifest::Remote(remote) => {
@@ -950,15 +949,14 @@ mod tests {
             }
             _ => panic!("Expected remote dependency"),
         }
-
-        // Second one should be the converted local
         assert_eq!(result[1].package, PackageName::unchecked("local-lib"));
     }
 
     #[test]
     fn test_empty_dependencies_returns_empty() {
+        let tmp = create_workspace_dirs(&["project"]);
         let publisher = create_test_publisher();
-        let base_path = PathBuf::from("/project");
+        let base_path = tmp.path().join("project");
 
         let manifest = PackagesManifest::builder()
             .dependencies(Default::default())

--- a/src/operations/publish.rs
+++ b/src/operations/publish.rs
@@ -2,7 +2,6 @@
 
 use std::collections::HashMap;
 use std::env;
-use std::fs;
 use std::path::Path;
 #[cfg(feature = "git")]
 use std::process::Stdio;
@@ -552,8 +551,9 @@ impl Publisher {
             }
         }
 
-        let remote_dependencies =
-            self.replace_local_with_remote_dependencies(&manifest, package_path).await?;
+        let remote_dependencies = self
+            .replace_local_with_remote_dependencies(&manifest, package_path)
+            .await?;
         tracing::debug!(
             "local dependencies replaced successfully, now have {} total remote dependencies",
             remote_dependencies.len()
@@ -749,6 +749,7 @@ mod tests {
     use crate::package::PackageName;
     use semver::VersionReq;
     use std::collections::HashMap;
+    use std::fs;
     use std::path::PathBuf;
     use std::str::FromStr;
 

--- a/src/operations/publish.rs
+++ b/src/operations/publish.rs
@@ -665,18 +665,17 @@ impl Publisher {
                     );
 
                     // Paths in the manifest are relative and need to be canonicalized to be used as unique keys
-                    let canonical_path =
-                        fs::canonicalize(base_path.join(&local_manifest.path).join(MANIFEST_FILE))
-                            .into_diagnostic()
-                            .wrap_err_with(|| {
-                                format!(
-                                    "failed to canonicalize dependency path: {}",
-                                    base_path
-                                        .join(&local_manifest.path)
-                                        .join(MANIFEST_FILE)
-                                        .display()
-                                )
-                            })?;
+                    let dependency_manifest_path =
+                        base_path.join(&local_manifest.path).join(MANIFEST_FILE);
+                    let canonical_path = tokio::fs::canonicalize(&dependency_manifest_path)
+                        .await
+                        .into_diagnostic()
+                        .wrap_err_with(|| {
+                            format!(
+                                "failed to canonicalize dependency path: {}",
+                                dependency_manifest_path.display()
+                            )
+                        })?;
                     let absolute_path_manifest = LocalDependencyManifest {
                         path: canonical_path,
                     };

--- a/src/operations/publish.rs
+++ b/src/operations/publish.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::env;
+use std::fs;
 use std::path::Path;
 #[cfg(feature = "git")]
 use std::process::Stdio;
@@ -473,7 +474,14 @@ impl Publisher {
             manifest_override.is_some()
         );
 
-        let manifest_path = package_path.join(MANIFEST_FILE);
+        let manifest_path = fs::canonicalize(package_path.join(MANIFEST_FILE))
+            .into_diagnostic()
+            .wrap_err_with(|| {
+                format!(
+                    "failed to canonicalize manifest path: {}",
+                    package_path.join(MANIFEST_FILE).display()
+                )
+            })?;
         tracing::debug!("  manifest_path: {}", manifest_path.display());
 
         // Check if this package has already been published (idempotent)
@@ -656,9 +664,22 @@ impl Publisher {
                         local_manifest.path.display()
                     );
 
-                    // Paths in the manifest are relative and need to be converted to absolute paths to be used as unique keys
+                    // Paths in the manifest are relative and need to be canonicalized to be used as unique keys
+                    let canonical_path = fs::canonicalize(
+                        base_path.join(&local_manifest.path).join(MANIFEST_FILE),
+                    )
+                    .into_diagnostic()
+                    .wrap_err_with(|| {
+                        format!(
+                            "failed to canonicalize dependency path: {}",
+                            base_path
+                                .join(&local_manifest.path)
+                                .join(MANIFEST_FILE)
+                                .display()
+                        )
+                    })?;
                     let absolute_path_manifest = LocalDependencyManifest {
-                        path: base_path.join(&local_manifest.path).join(MANIFEST_FILE),
+                        path: canonical_path,
                     };
                     tracing::debug!("  absolute path: {}", absolute_path_manifest.path.display());
 

--- a/tests/cmd/publish/workspace/mod.rs
+++ b/tests/cmd/publish/workspace/mod.rs
@@ -1,2 +1,3 @@
 mod set_version;
 mod set_version_with_local_deps;
+mod shared_dep_via_different_paths;

--- a/tests/cmd/publish/workspace/set_version_with_local_deps/stdout.log
+++ b/tests/cmd/publish/workspace/set_version_with_local_deps/stdout.log
@@ -9,5 +9,3 @@
 :: published my-repository/api-b@5.0.0
 :: processing workspace member 2/2: lib-a
 :: modified version in published manifest for lib-a from 0.1.0 to 5.0.0
-:: packaged lib-a@5.0.0
-:: my-repository/lib-a@5.0.0 is already published, skipping

--- a/tests/cmd/publish/workspace/shared_dep_via_different_paths/in/Proto.toml
+++ b/tests/cmd/publish/workspace/shared_dep_via_different_paths/in/Proto.toml
@@ -1,0 +1,4 @@
+edition = "0.13"
+
+[workspace]
+members = ["consumer"]

--- a/tests/cmd/publish/workspace/shared_dep_via_different_paths/in/api-a/Proto.toml
+++ b/tests/cmd/publish/workspace/shared_dep_via_different_paths/in/api-a/Proto.toml
@@ -1,0 +1,9 @@
+edition = "0.13"
+
+[package]
+type = "api"
+name = "api-a"
+version = "0.1.0"
+
+[dependencies]
+"shared-lib" = { path = "../shared-lib" }

--- a/tests/cmd/publish/workspace/shared_dep_via_different_paths/in/api-a/proto/api_a.proto
+++ b/tests/cmd/publish/workspace/shared_dep_via_different_paths/in/api-a/proto/api_a.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package workspace.api_a;
+
+import "shared.proto";
+
+message ApiAMessage {
+  workspace.shared.SharedMessage shared = 1;
+}

--- a/tests/cmd/publish/workspace/shared_dep_via_different_paths/in/api-b/Proto.toml
+++ b/tests/cmd/publish/workspace/shared_dep_via_different_paths/in/api-b/Proto.toml
@@ -1,0 +1,9 @@
+edition = "0.13"
+
+[package]
+type = "api"
+name = "api-b"
+version = "0.1.0"
+
+[dependencies]
+"shared-lib" = { path = "../shared-lib" }

--- a/tests/cmd/publish/workspace/shared_dep_via_different_paths/in/api-b/proto/api_b.proto
+++ b/tests/cmd/publish/workspace/shared_dep_via_different_paths/in/api-b/proto/api_b.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package workspace.api_b;
+
+import "shared.proto";
+
+message ApiBMessage {
+  workspace.shared.SharedMessage shared = 1;
+}

--- a/tests/cmd/publish/workspace/shared_dep_via_different_paths/in/consumer/Proto.toml
+++ b/tests/cmd/publish/workspace/shared_dep_via_different_paths/in/consumer/Proto.toml
@@ -1,0 +1,10 @@
+edition = "0.13"
+
+[package]
+type = "api"
+name = "consumer"
+version = "0.1.0"
+
+[dependencies]
+"api-a" = { path = "../api-a" }
+"api-b" = { path = "../api-b" }

--- a/tests/cmd/publish/workspace/shared_dep_via_different_paths/in/consumer/proto/consumer.proto
+++ b/tests/cmd/publish/workspace/shared_dep_via_different_paths/in/consumer/proto/consumer.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package workspace.consumer;
+
+import "api_a.proto";
+import "api_b.proto";
+
+message ConsumerMessage {
+  workspace.api_a.ApiAMessage a = 1;
+  workspace.api_b.ApiBMessage b = 2;
+}

--- a/tests/cmd/publish/workspace/shared_dep_via_different_paths/in/shared-lib/Proto.toml
+++ b/tests/cmd/publish/workspace/shared_dep_via_different_paths/in/shared-lib/Proto.toml
@@ -1,0 +1,8 @@
+edition = "0.13"
+
+[package]
+type = "lib"
+name = "shared-lib"
+version = "0.1.0"
+
+[dependencies]

--- a/tests/cmd/publish/workspace/shared_dep_via_different_paths/in/shared-lib/proto/shared.proto
+++ b/tests/cmd/publish/workspace/shared_dep_via_different_paths/in/shared-lib/proto/shared.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package workspace.shared;
+
+message SharedMessage {
+  string value = 1;
+}

--- a/tests/cmd/publish/workspace/shared_dep_via_different_paths/mod.rs
+++ b/tests/cmd/publish/workspace/shared_dep_via_different_paths/mod.rs
@@ -1,0 +1,32 @@
+use crate::{VirtualFileSystem, with_test_registry};
+
+/// Regression test for path canonicalization in workspace publishing.
+///
+/// When a workspace member (consumer) depends on two APIs (api-a, api-b)
+/// that both depend on the same shared library (shared-lib), the publish
+/// process resolves shared-lib via different relative paths:
+///
+///   - consumer/../api-a/../shared-lib (via api-a's dependency chain)
+///   - consumer/../api-b/../shared-lib (via api-b's dependency chain)
+///
+/// Without path canonicalization, these are treated as different keys in
+/// the manifest_mappings HashMap, causing the second lookup to fail with
+/// "local dependency should have been made available during publish".
+#[test]
+fn fixture() {
+    with_test_registry(|url| {
+        let vfs = VirtualFileSystem::copy(crate::parent_directory!().join("in"));
+
+        crate::cli!()
+            .arg("publish")
+            .arg("--registry")
+            .arg(url)
+            .arg("--repository")
+            .arg("my-repository")
+            .arg("--set-version")
+            .arg("1.0.0")
+            .current_dir(vfs.root())
+            .assert()
+            .success();
+    });
+}


### PR DESCRIPTION
The remote version resolution for complex buffrs workspaces was limited and caused hard to understand errors; this PR resolves this limitation by canonicalizing paths during publishing to identify whether two packages point to the same shared package:

```
/pkg-a
/pkg-b # imports a
/pkg-c # imports b
```

Caused errors, because the relative import paths to a are not the same during version resolution: Pkg B imports Pkg A using `../pkg-a`, whereas Pkg C imports Pkg B using `../pkg-b`, now due to the transitive dependency to Pkg A, the chaining of local paths caused the references to Pkg A to diverge: `../pkg-a` vs `../pkg-b/../pkg-a` - thus identifying whether a version for this package was already published failed.

This PR now canonicalizes paths: `../pkg-a` becomes `<project>/pkg-a` and `../pkg-b/../pkg-a` also becomes `<project>/pkg-a` allowing buffrs to correctly identify whether it already published the transitive dependency.