### PR TITLE
Prevent 'missing package declaration' errors during publishing

### DIFF
--- a/src/manifest/package.rs
+++ b/src/manifest/package.rs
@@ -113,6 +113,43 @@ impl PackagesManifest {
     }
 }
 
+/// A [`PackagesManifest`] guaranteed to contain a `[package]` declaration.
+///
+/// Created via [`PublishableManifest::try_new`], which returns `None` when
+/// the manifest has no package section (e.g. dependency-only workspace members).
+#[derive(Clone, Debug)]
+pub struct PublishableManifest(PackagesManifest);
+
+impl PublishableManifest {
+    /// Creates a new `PublishableManifest` if the manifest contains a package declaration.
+    ///
+    /// Returns `None` when `manifest.package` is `None`.
+    pub fn try_new(manifest: PackagesManifest) -> Option<Self> {
+        manifest.package.as_ref()?;
+        Some(Self(manifest))
+    }
+
+    /// Returns a reference to the package metadata.
+    ///
+    /// This never fails because `PublishableManifest` guarantees a package is present.
+    pub fn package(&self) -> &PackageManifest {
+        self.0
+            .package
+            .as_ref()
+            .expect("PublishableManifest guarantees package is Some")
+    }
+
+    /// Returns a reference to the inner `PackagesManifest`.
+    pub fn inner(&self) -> &PackagesManifest {
+        &self.0
+    }
+
+    /// Unwraps the inner `PackagesManifest`.
+    pub fn into_inner(self) -> PackagesManifest {
+        self.0
+    }
+}
+
 /// Builder for constructing a PackagesManifest
 pub struct PackagesManifestBuilder {
     edition: Edition,

--- a/src/manifest/package.rs
+++ b/src/manifest/package.rs
@@ -573,6 +573,34 @@ mod tests {
     }
 
     #[test]
+    fn publishable_manifest_try_new_returns_none_without_package() {
+        let manifest = PackagesManifest::builder()
+            .dependencies(Default::default())
+            .build();
+
+        assert!(PublishableManifest::try_new(manifest).is_none());
+    }
+
+    #[test]
+    fn publishable_manifest_try_new_returns_some_with_package() {
+        let manifest = PackagesManifest::builder()
+            .package(PackageManifest {
+                kind: PackageType::Lib,
+                name: PackageName::from_str("test-pkg").unwrap(),
+                version: Version::new(1, 0, 0),
+                description: None,
+            })
+            .dependencies(Default::default())
+            .build();
+
+        let publishable = PublishableManifest::try_new(manifest).expect("should be Some");
+        assert_eq!(
+            publishable.package().name,
+            PackageName::from_str("test-pkg").unwrap()
+        );
+    }
+
+    #[test]
     fn packages_manifest_roundtrip() {
         let toml = r#"
                 edition = "0.12"

--- a/src/operations/publish.rs
+++ b/src/operations/publish.rs
@@ -997,7 +997,10 @@ mod tests {
             .build();
 
         let publishable = PublishableManifest::try_new(manifest).expect("should be Some");
-        assert_eq!(publishable.package().name, PackageName::unchecked("test-pkg"));
+        assert_eq!(
+            publishable.package().name,
+            PackageName::unchecked("test-pkg")
+        );
     }
 
     #[tokio::test]

--- a/src/operations/publish.rs
+++ b/src/operations/publish.rs
@@ -14,7 +14,7 @@ use crate::{
     credentials::Credentials,
     manifest::{
         Dependency, DependencyManifest, LocalDependencyManifest, MANIFEST_FILE, Manifest,
-        PackagesManifest, RemoteDependencyManifest, WorkspaceManifest,
+        PackagesManifest, PublishableManifest, RemoteDependencyManifest, WorkspaceManifest,
     },
     operations::install::NetworkMode,
     package::PackageStore,
@@ -274,7 +274,9 @@ impl Publisher {
             package_path.display()
         );
         tracing::debug!("passing modified root_manifest with potentially overridden version");
-        self.publish_package_at_path(package_path, Some(&root_manifest))
+        let root_publishable = PublishableManifest::try_new(root_manifest)
+            .ok_or_else(|| miette!("manifest has no package declaration"))?;
+        self.publish_package_at_path(package_path, Some(&root_publishable))
             .await?;
         tracing::debug!("root package published successfully");
 
@@ -408,7 +410,12 @@ impl Publisher {
                                 .await?
                                 .with_version(version.clone());
 
-                        Some(dep_manifest)
+                        Some(PublishableManifest::try_new(dep_manifest).ok_or_else(|| {
+                            miette!(
+                                "local dependency at {} has no package declaration",
+                                absolute_path.display()
+                            )
+                        })?)
                     } else {
                         None
                     };
@@ -439,13 +446,20 @@ impl Publisher {
                 );
             }
 
-            tracing::debug!(
-                "publishing workspace member at path: {}",
-                member_path.display()
-            );
-            self.publish_package_at_path(member_path, Some(&member_manifest))
-                .await?;
-            tracing::debug!("workspace member published successfully");
+            if let Some(publishable) = PublishableManifest::try_new(member_manifest) {
+                tracing::debug!(
+                    "publishing workspace member at path: {}",
+                    member_path.display()
+                );
+                self.publish_package_at_path(member_path, Some(&publishable))
+                    .await?;
+                tracing::debug!("workspace member published successfully");
+            } else {
+                tracing::debug!(
+                    "skipping workspace member at {}: no package declaration (dependency-only member)",
+                    member_path.display()
+                );
+            }
         }
 
         tracing::debug!("all workspace members published successfully");
@@ -464,7 +478,7 @@ impl Publisher {
     async fn publish_package_at_path(
         &mut self,
         package_path: &Path,
-        manifest_override: Option<&PackagesManifest>,
+        manifest_override: Option<&PublishableManifest>,
     ) -> miette::Result<()> {
         tracing::debug!("publish_package_at_path() called");
         tracing::debug!("  package_path: {}", package_path.display());
@@ -505,7 +519,7 @@ impl Publisher {
 
         let manifest = if let Some(manifest_override) = manifest_override {
             tracing::debug!("using provided manifest override instead of reading from disk");
-            manifest_override.clone()
+            manifest_override.inner().clone()
         } else {
             tracing::debug!("IO: reading manifest from {}", manifest_path.display());
             Manifest::require_package_manifest(&manifest_path)
@@ -955,6 +969,35 @@ mod tests {
             _ => panic!("Expected remote dependency"),
         }
         assert_eq!(result[1].package, PackageName::unchecked("local-lib"));
+    }
+
+    #[test]
+    fn test_publishable_manifest_try_new_returns_none_without_package() {
+        let manifest = PackagesManifest::builder()
+            .dependencies(Default::default())
+            .build();
+
+        assert!(PublishableManifest::try_new(manifest).is_none());
+    }
+
+    #[test]
+    fn test_publishable_manifest_try_new_returns_some_with_package() {
+        use crate::manifest::PackageManifest;
+        use crate::package::PackageType;
+        use semver::Version;
+
+        let manifest = PackagesManifest::builder()
+            .package(PackageManifest {
+                kind: PackageType::Lib,
+                name: PackageName::unchecked("test-pkg"),
+                version: Version::new(1, 0, 0),
+                description: None,
+            })
+            .dependencies(Default::default())
+            .build();
+
+        let publishable = PublishableManifest::try_new(manifest).expect("should be Some");
+        assert_eq!(publishable.package().name, PackageName::unchecked("test-pkg"));
     }
 
     #[tokio::test]

--- a/src/operations/publish.rs
+++ b/src/operations/publish.rs
@@ -274,8 +274,12 @@ impl Publisher {
             package_path.display()
         );
         tracing::debug!("passing modified root_manifest with potentially overridden version");
-        let root_publishable = PublishableManifest::try_new(root_manifest)
-            .ok_or_else(|| miette!("manifest has no package declaration"))?;
+        let root_publishable = PublishableManifest::try_new(root_manifest).ok_or_else(|| {
+            miette!(
+                "manifest has no package declaration: {}",
+                package_path.display()
+            )
+        })?;
         self.publish_package_at_path(package_path, Some(&root_publishable))
             .await?;
         tracing::debug!("root package published successfully");

--- a/src/operations/publish.rs
+++ b/src/operations/publish.rs
@@ -189,6 +189,14 @@ impl Publisher {
 
         let root_manifest = manifest.clone().with_version(version);
 
+        // Validate package declaration early, before any side effects
+        let root_publishable = PublishableManifest::try_new(root_manifest).ok_or_else(|| {
+            miette!(
+                "manifest has no package declaration: {}",
+                package_path.display()
+            )
+        })?;
+
         // Build dependency graph
         tracing::debug!(
             "building dependency graph for package at {}",
@@ -198,7 +206,7 @@ impl Publisher {
         tracing::debug!("credentials loaded for dependency graph building");
 
         let graph = DependencyGraph::build(
-            &root_manifest,
+            root_publishable.inner(),
             package_path,
             &credentials,
             None,
@@ -261,21 +269,18 @@ impl Publisher {
         }
 
         // Populate and publish the root package
-        if let Some(ref pkg) = root_manifest.package {
-            tracing::debug!("populating package store for package: {}", pkg.name);
-            tracing::debug!("  package version: {}", pkg.version);
-            tracing::debug!("  package kind: {:?}", pkg.kind);
-            store.populate(pkg).await?;
-            tracing::debug!("package store populated successfully for {}", pkg.name);
-        }
+        let pkg = root_publishable.package();
+        tracing::debug!("populating package store for package: {}", pkg.name);
+        tracing::debug!("  package version: {}", pkg.version);
+        tracing::debug!("  package kind: {:?}", pkg.kind);
+        store.populate(pkg).await?;
+        tracing::debug!("package store populated successfully for {}", pkg.name);
 
         tracing::debug!(
             "publishing root package at path: {}",
             package_path.display()
         );
         tracing::debug!("passing modified root_manifest with potentially overridden version");
-        let root_publishable = PublishableManifest::try_new(root_manifest)
-            .ok_or_else(|| miette!("manifest has no package declaration"))?;
         self.publish_package_at_path(package_path, Some(&root_publishable))
             .await?;
         tracing::debug!("root package published successfully");
@@ -333,6 +338,15 @@ impl Publisher {
             let member_manifest = Manifest::require_package_manifest(&manifest_file)
                 .await?
                 .with_version(version.clone());
+
+            // Skip dependency-only members early
+            if member_manifest.package.is_none() {
+                tracing::debug!(
+                    "skipping workspace member at {}: no package declaration (dependency-only member)",
+                    member_path.display()
+                );
+                continue;
+            }
 
             tracing::debug!("manifest loaded successfully");
 
@@ -446,20 +460,15 @@ impl Publisher {
                 );
             }
 
-            if let Some(publishable) = PublishableManifest::try_new(member_manifest) {
-                tracing::debug!(
-                    "publishing workspace member at path: {}",
-                    member_path.display()
-                );
-                self.publish_package_at_path(member_path, Some(&publishable))
-                    .await?;
-                tracing::debug!("workspace member published successfully");
-            } else {
-                tracing::debug!(
-                    "skipping workspace member at {}: no package declaration (dependency-only member)",
-                    member_path.display()
-                );
-            }
+            let publishable = PublishableManifest::try_new(member_manifest)
+                .expect("package declaration was already validated above");
+            tracing::debug!(
+                "publishing workspace member at path: {}",
+                member_path.display()
+            );
+            self.publish_package_at_path(member_path, Some(&publishable))
+                .await?;
+            tracing::debug!("workspace member published successfully");
         }
 
         tracing::debug!("all workspace members published successfully");
@@ -969,38 +978,6 @@ mod tests {
             _ => panic!("Expected remote dependency"),
         }
         assert_eq!(result[1].package, PackageName::unchecked("local-lib"));
-    }
-
-    #[test]
-    fn test_publishable_manifest_try_new_returns_none_without_package() {
-        let manifest = PackagesManifest::builder()
-            .dependencies(Default::default())
-            .build();
-
-        assert!(PublishableManifest::try_new(manifest).is_none());
-    }
-
-    #[test]
-    fn test_publishable_manifest_try_new_returns_some_with_package() {
-        use crate::manifest::PackageManifest;
-        use crate::package::PackageType;
-        use semver::Version;
-
-        let manifest = PackagesManifest::builder()
-            .package(PackageManifest {
-                kind: PackageType::Lib,
-                name: PackageName::unchecked("test-pkg"),
-                version: Version::new(1, 0, 0),
-                description: None,
-            })
-            .dependencies(Default::default())
-            .build();
-
-        let publishable = PublishableManifest::try_new(manifest).expect("should be Some");
-        assert_eq!(
-            publishable.package().name,
-            PackageName::unchecked("test-pkg")
-        );
     }
 
     #[tokio::test]

--- a/tests/cmd/publish/workspace/mixed_members/in/Proto.toml
+++ b/tests/cmd/publish/workspace/mixed_members/in/Proto.toml
@@ -1,0 +1,4 @@
+edition = "0.13"
+
+[workspace]
+members = ["lib-a", "consumer"]

--- a/tests/cmd/publish/workspace/mixed_members/in/consumer/Proto.toml
+++ b/tests/cmd/publish/workspace/mixed_members/in/consumer/Proto.toml
@@ -1,0 +1,4 @@
+edition = "0.13"
+
+[dependencies]
+"lib-a" = { path = "../lib-a" }

--- a/tests/cmd/publish/workspace/mixed_members/in/lib-a/Proto.toml
+++ b/tests/cmd/publish/workspace/mixed_members/in/lib-a/Proto.toml
@@ -1,0 +1,8 @@
+edition = "0.13"
+
+[package]
+type = "lib"
+name = "lib-a"
+version = "1.0.0"
+
+[dependencies]

--- a/tests/cmd/publish/workspace/mixed_members/in/lib-a/proto/lib_a.proto
+++ b/tests/cmd/publish/workspace/mixed_members/in/lib-a/proto/lib_a.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package workspace.lib_a;
+
+message LibMessage {
+  string data = 1;
+}

--- a/tests/cmd/publish/workspace/mixed_members/mod.rs
+++ b/tests/cmd/publish/workspace/mixed_members/mod.rs
@@ -1,0 +1,25 @@
+use crate::{VirtualFileSystem, with_test_registry};
+
+/// Test that a workspace with a mix of publishable and dependency-only
+/// members succeeds: publishable members (with `[package]`) are published
+/// while dependency-only members (without `[package]`) are silently skipped.
+#[test]
+fn fixture() {
+    with_test_registry(|url| {
+        let vfs = VirtualFileSystem::copy(crate::parent_directory!().join("in"));
+
+        crate::cli!()
+            .arg("publish")
+            .arg("--registry")
+            .arg(url)
+            .arg("--repository")
+            .arg("my-repository")
+            .arg("--set-version")
+            .arg("1.0.0")
+            .current_dir(vfs.root())
+            .assert()
+            .success()
+            .stdout(include_str!("stdout.log"))
+            .stderr(include_str!("stderr.log"));
+    });
+}

--- a/tests/cmd/publish/workspace/mixed_members/stdout.log
+++ b/tests/cmd/publish/workspace/mixed_members/stdout.log
@@ -1,0 +1,6 @@
+:: workspace found. publishing 2 packages in workspace
+:: processing workspace member 1/2: consumer
+:: processing workspace member 2/2: lib-a
+:: modified version in published manifest for lib-a from 1.0.0 to 1.0.0
+:: packaged lib-a@1.0.0
+:: published my-repository/lib-a@1.0.0

--- a/tests/cmd/publish/workspace/mod.rs
+++ b/tests/cmd/publish/workspace/mod.rs
@@ -1,3 +1,4 @@
+mod mixed_members;
 mod set_version;
 mod set_version_with_local_deps;
 mod shared_dep_via_different_paths;


### PR DESCRIPTION
This PR repairs and prevents 'missing package declaration' errors in the future, as it creates a new type around package manifests, which ensures that a manifest is publishable before handing it to the actual publishing code. This prevents manifests without a `[package]` section being passed onto branches which can't work without this section using type signatures.