### PR TITLE
fixes two broken links to the `buffrs` announcement post

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Useful resources:
 
 - [The Buffrs Book](https://helsing-ai.github.io/buffrs)
 - [Crate Documentation](https://docs.rs/buffrs)
-- [Announcement Post](https://blog.helsing.ai/buffrs-a-package-manager-for-protocol-buffers-1-2-aaf7c00153d2)
+- [Announcement Post](https://blog.helsing.ai/posts/buffrs-a-package-manager-for-protocol-buffers-12)
 - `buffrs help`
 
 ## Features

--- a/docs/src/guide/why-buffrs-exists.md
+++ b/docs/src/guide/why-buffrs-exists.md
@@ -21,7 +21,7 @@ _[announcement post.]_
 
 <!-- ### Differerntion -->
 
-[announcement post.]: https://blog.helsing.ai/buffrs-a-package-manager-for-protocol-buffers-1-2-aaf7c00153d2
+[announcement post.]: https://blog.helsing.ai/posts/buffrs-a-package-manager-for-protocol-buffers-12
 [buf]: https://buf.build/
 [bazel]: https://bazel.build/
 [git submodules]: https://git-scm.com/book/en/v2/Git-Tools-Submodules


### PR DESCRIPTION
This tiny PR fixes two `404` to the `buffrs` announcement post.