### PR TITLE
Non-IFD Nix Integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,9 +1627,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,15 @@
           lib.vendorDependencies =
             pkgs.callPackage ./nix/cache.nix { buffrs = buffrs.package; };
 
+          # Pure-Nix alternative: parses `Proto.lock` directly with
+          # `fromTOML` instead of shelling out to `buffrs lock
+          # print-files` under IFD. Use this when the caller may
+          # evaluate `vendorDependencies` for a system it can't
+          # build (e.g. enumerating `aarch64-darwin` outputs from
+          # `x86_64-linux` via flake-parts).
+          lib.vendorDependenciesPure =
+            pkgs.callPackage ./nix/cache-pure.nix { };
+
           devShells.default = pkgs.mkShell ({
             nativeBuildInputs = nativeBuildInputs ++ [ pkgs.protobuf ];
             buildInputs = devTools ++ dependencies;

--- a/nix/cache-pure.nix
+++ b/nix/cache-pure.nix
@@ -1,0 +1,45 @@
+# Pure-Nix variant of `cache.nix` — same `BUFFRS_CACHE` output, but
+# the URL list is derived by parsing `Proto.lock` with `fromTOML`
+# instead of invoking `buffrs lock print-files` under IFD.
+#
+# Use this when the caller evaluates `vendorDependencies` for a
+# system it can't build (e.g. enumerating `aarch64-darwin` outputs
+# from `x86_64-linux` via flake-parts). The IFD variant in
+# `cache.nix` would force `buffrs-urls` to build on the foreign
+# system; this one avoids that entirely.
+#
+# URL construction mirrors `FileRequirement::new` in `src/lock.rs`:
+#   <registry>/<repository>/<name>/<name>-<version>.tgz
+# Keep this in sync if the on-the-wire layout changes.
+{ fetchurl, runCommand, lib, symlinkJoin, }:
+
+lockfile:
+
+let
+  lock = builtins.fromTOML (builtins.readFile lockfile);
+  packages = lock.packages or [ ];
+
+  fileUrl = pkg:
+    "${pkg.registry}/${pkg.repository}/${pkg.name}/${pkg.name}-${pkg.version}.tgz";
+
+  cachePackage = pkg:
+    let
+      prefix = "sha256:";
+      sha256 = assert lib.strings.hasPrefix prefix pkg.digest;
+        lib.strings.removePrefix prefix pkg.digest;
+      tar = fetchurl {
+        inherit sha256;
+        url = fileUrl pkg;
+      };
+    in runCommand "cache-${pkg.name}" { } ''
+      mkdir -p $out
+      cp ${tar} $out/${pkg.name}.sha256.${sha256}.tgz
+    '';
+
+  cache = map cachePackage packages;
+in {
+  BUFFRS_CACHE = symlinkJoin {
+    name = "buffrs-cache";
+    paths = cache;
+  };
+}


### PR DESCRIPTION
This MR adds a non-IFD variant of the `cache.nix` which circumvents frequent rebuilding and performance bottlenecks on buffrs in nix. Reference on IFD: https://nix.dev/manual/nix/2.26/language/import-from-derivation