### PR TITLE
refactor(tests): introduce shared helper for package publishing

### DIFF
--- a/tests/cmd/install/package/offline/mod.rs
+++ b/tests/cmd/install/package/offline/mod.rs
@@ -8,30 +8,16 @@ fn fixture() {
         let cwd = vfs.root();
 
         // Publish a remote-lib to the registry
-        {
-            std::fs::create_dir(cwd.join("remote-lib")).unwrap();
-            let lib_dir = cwd.join("remote-lib");
-
-            crate::cli!()
-                .args(["init", "--lib", "remote-lib"])
-                .env("BUFFRS_HOME", &buffrs_home)
-                .current_dir(&lib_dir)
-                .assert()
-                .success();
-
-            std::fs::write(
-                lib_dir.join("proto/remote.proto"),
-                "syntax = \"proto3\";\n\npackage remote;\n\nmessage Data {\n  string value = 1;\n}\n",
-            )
-            .unwrap();
-
-            crate::cli!()
-                .args(["publish", "--registry", url, "--repository", "test-repo"])
-                .env("BUFFRS_HOME", &buffrs_home)
-                .current_dir(&lib_dir)
-                .assert()
-                .success();
-        }
+        crate::publish_test_library(
+            &cwd,
+            &buffrs_home,
+            url,
+            "test-repo",
+            "remote-lib",
+            None,
+            "remote.proto",
+            "syntax = \"proto3\";\n\npackage remote;\n\nmessage Data {\n  string value = 1;\n}\n",
+        );
 
         // Add the dependency
         crate::cli!()

--- a/tests/cmd/install/package/online/mod.rs
+++ b/tests/cmd/install/package/online/mod.rs
@@ -8,30 +8,16 @@ fn fixture() {
         let cwd = vfs.root();
 
         // Publish a remote-lib to the registry
-        {
-            std::fs::create_dir(cwd.join("remote-lib")).unwrap();
-            let lib_dir = cwd.join("remote-lib");
-
-            crate::cli!()
-                .args(["init", "--lib", "remote-lib"])
-                .env("BUFFRS_HOME", &buffrs_home)
-                .current_dir(&lib_dir)
-                .assert()
-                .success();
-
-            std::fs::write(
-                lib_dir.join("proto/remote.proto"),
-                "syntax = \"proto3\";\n\npackage remote;\n\nmessage Data {\n  string value = 1;\n}\n",
-            )
-            .unwrap();
-
-            crate::cli!()
-                .args(["publish", "--registry", url, "--repository", "test-repo"])
-                .env("BUFFRS_HOME", &buffrs_home)
-                .current_dir(&lib_dir)
-                .assert()
-                .success();
-        }
+        crate::publish_test_library(
+            &cwd,
+            &buffrs_home,
+            url,
+            "test-repo",
+            "remote-lib",
+            None,
+            "remote.proto",
+            "syntax = \"proto3\";\n\npackage remote;\n\nmessage Data {\n  string value = 1;\n}\n",
+        );
 
         // Add the dependency
         crate::cli!()

--- a/tests/cmd/install/workspace/creates_lockfile/mod.rs
+++ b/tests/cmd/install/workspace/creates_lockfile/mod.rs
@@ -8,30 +8,16 @@ fn fixture() {
         let cwd = vfs.root();
 
         // Create and publish remote-lib to the test registry
-        {
-            std::fs::create_dir(cwd.join("remote-lib")).unwrap();
-            let lib_dir = cwd.join("remote-lib");
-
-            crate::cli!()
-                .args(["init", "--lib", "remote-lib"])
-                .env("BUFFRS_HOME", &buffrs_home)
-                .current_dir(&lib_dir)
-                .assert()
-                .success();
-
-            std::fs::write(
-                lib_dir.join("proto/remote.proto"),
-                "syntax = \"proto3\";\n\npackage remote;\n\nmessage Data {\n  string value = 1;\n}\n",
-            )
-            .unwrap();
-
-            crate::cli!()
-                .args(["publish", "--registry", url, "--repository", "test-repo"])
-                .env("BUFFRS_HOME", &buffrs_home)
-                .current_dir(&lib_dir)
-                .assert()
-                .success();
-        }
+        crate::publish_test_library(
+            &cwd,
+            &buffrs_home,
+            url,
+            "test-repo",
+            "remote-lib",
+            None,
+            "remote.proto",
+            "syntax = \"proto3\";\n\npackage remote;\n\nmessage Data {\n  string value = 1;\n}\n",
+        );
 
         // Add remote-lib to pkg1
         crate::cli!()

--- a/tests/helper/mod.rs
+++ b/tests/helper/mod.rs
@@ -1,0 +1,50 @@
+use std::path::Path;
+
+/// Helper to create, initialize, write a proto file, and publish a library package.
+#[allow(clippy::too_many_arguments)]
+pub fn publish_test_library(
+    cwd: &Path,
+    buffrs_home: &Path,
+    registry_url: &str,
+    repository: &str,
+    name: &str,
+    version: Option<&str>,
+    proto_filename: &str,
+    proto_content: &str,
+) {
+    let lib_dir = cwd.join(name);
+    std::fs::create_dir_all(&lib_dir).unwrap();
+
+    crate::cli!()
+        .args(["init", "--lib", name])
+        .env("BUFFRS_HOME", buffrs_home)
+        .current_dir(&lib_dir)
+        .assert()
+        .success();
+
+    if let Some(version) = version {
+        let manifest_path = lib_dir.join("Proto.toml");
+        let manifest = std::fs::read_to_string(&manifest_path).unwrap();
+        let updated = manifest.replace("version = \"0.1.0\"", &format!("version = \"{version}\""));
+        std::fs::write(&manifest_path, updated).unwrap();
+    }
+
+    let proto_path = lib_dir.join(format!("proto/{proto_filename}"));
+    if let Some(parent) = proto_path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(proto_path, proto_content).unwrap();
+
+    crate::cli!()
+        .args([
+            "publish",
+            "--registry",
+            registry_url,
+            "--repository",
+            repository,
+        ])
+        .env("BUFFRS_HOME", buffrs_home)
+        .current_dir(&lib_dir)
+        .assert()
+        .success();
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -8,10 +8,12 @@ use pretty_assertions::{assert_eq, assert_str_eq};
 
 mod cmd;
 mod compat;
+mod helper;
 mod nix;
 mod registry;
 mod resolver;
 
+pub use helper::*;
 pub use registry::*;
 
 /// Create a command which runs the cli


### PR DESCRIPTION
Closes #312.

Several integration tests contained identical setup code for creating, initializing, writing a proto file, and publishing a library package. This PR extracts that common logic into a shared helper to reduce duplication and improve maintainability.

### Changes

* Added a shared `publish_test_library` helper in `tests/helper/mod.rs`.
* Exposed the helper from `tests/lib.rs`.
* Refactored the following integration tests to use the helper:

  * `cmd/install/package/online`
  * `cmd/install/package/offline`
  * `cmd/install/workspace/creates_lockfile`

The refactoring preserves the existing test behavior while removing duplicated setup code.

### Validation

* ✅ `cargo fmt`
* ✅ `cargo clippy --all-targets --all-features`
* ✅ Refactored tests pass locally
* ✅ Full test suite produces the same baseline results as before this change
