### PR TITLE
docs(cli): clarify preserve-mtime help text

### DIFF
--- a/docs/src/commands/buffrs-install.md
+++ b/docs/src/commands/buffrs-install.md
@@ -70,5 +70,5 @@ using the `BUFFRS_CACHE` environment variable (see
 
 #### `--preserve-local-mtime`
 
-Preserve access time information when installing a local dependency. Defaults to
+Preserve modification time information when installing a local dependency. Defaults to
 `true`.

--- a/docs/src/commands/buffrs-package.md
+++ b/docs/src/commands/buffrs-package.md
@@ -11,7 +11,7 @@ Generates a release tarball for the package in the current directory.
 * `--dry-run`: prevents buffrs from actually writing the tarball to the filesystem
 * `--output-directory`: allows you to specify a directory to output the package
 * `--set-version`: allows you to override the version set in the manifest
-* `--preserve-mtime`: preserve access time information when creating a package (defaults to `false`)
+* `--preserve-mtime`: preserve modification time information when creating a package (defaults to `false`)
 
 
 ### Description

--- a/docs/src/commands/buffrs-publish.md
+++ b/docs/src/commands/buffrs-publish.md
@@ -13,7 +13,7 @@ uncommitted changes.
 * `--dry-run`: causes a release bundle to be generated but skips uploading to
   the registry.
 * `--set-version`: allows you to override the version set in the manifest
-* `--preserve-mtime`: preserve access time information when creating a package (defaults to `true`)
+* `--preserve-mtime`: preserve modification time information when creating a package (defaults to `true`)
 
 ### Description
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,7 @@ enum Command {
         /// Note: This overrides the version in the manifest.
         #[clap(long)]
         set_version: Option<Version>,
-        /// Indicate whether access time information is preserved when creating a package.
+        /// Indicate whether modification time information is preserved when creating a package.
         #[clap(long)]
         #[arg(default_value_t = false)]
         preserve_mtime: bool,
@@ -127,7 +127,7 @@ enum Command {
         /// Note: This overrides the version in the manifest.
         #[clap(long)]
         set_version: Option<Version>,
-        /// Indicate whether access time information is preserved when creating a package.
+        /// Indicate whether modification time information is preserved when creating a package.
         #[clap(long)]
         #[arg(default_value_t = true)]
         preserve_mtime: bool,
@@ -135,7 +135,7 @@ enum Command {
 
     /// Installs dependencies
     Install {
-        /// Indicate whether access time information is preserved when installing a local.
+        /// Indicate whether modification time information is preserved when installing a local.
         #[clap(long)]
         #[arg(default_value_t = true)]
         preserve_local_mtime: bool,


### PR DESCRIPTION
## Summary

Clarify the user-facing help text for the `--preserve-mtime` and `--preserve-local-mtime` flags.

Previously, the help text referred to preserving the file access time, while the implementation preserves the file modification time by setting the tar archive's mtime.

This change updates:
- CLI help text in `main.rs`
- Generated command documentation in `buffrs-install.md`
- Generated command documentation in `buffrs-package.md`
- Generated command documentation in `buffrs-publish.md`

## Why

This brings the documentation in line with the existing implementation without changing behavior.